### PR TITLE
Only retry on certain exceptions

### DIFF
--- a/llm_gateway/providers/openai.py
+++ b/llm_gateway/providers/openai.py
@@ -28,6 +28,9 @@ from llm_gateway.db.utils import write_record_to_db
 from llm_gateway.pii_scrubber import scrub_all
 from llm_gateway.utils import max_retries
 
+from openai.error import Timeout, APIError, APIConnectionError, TryAgain
+
+OPENAI_EXCEPTIONS = [Timeout, APIError, APIConnectionError, TryAgain]
 SUPPORTED_OPENAI_ENDPOINTS = {
     "Model": ["list", "retrieve"],
     "ChatCompletion": ["create"],
@@ -69,7 +72,7 @@ class OpenAIWrapper:
                 f"`{endpoint}` not supported action for `{module}`"
             )
 
-    @max_retries(3)
+    @max_retries(3, exceptions=OPENAI_EXCEPTIONS)
     def _call_model_endpoint(self, endpoint: str, model: Optional[str] = None):
         """
         List or retrieve model(s) from OpenAI
@@ -90,7 +93,7 @@ class OpenAIWrapper:
                 raise Exception("retrieve model needs model name as input")
             return openai.Model.retrieve(model)
 
-    @max_retries(3)
+    @max_retries(3, exceptions=OPENAI_EXCEPTIONS)
     def _call_completion_endpoint(
         self, prompt: str, model: str, max_tokens: int, temperature: float, **kwargs
     ):
@@ -117,7 +120,7 @@ class OpenAIWrapper:
             **kwargs,
         )
 
-    @max_retries(3)
+    @max_retries(3, exceptions=OPENAI_EXCEPTIONS)
     def _call_chat_completion_endpoint(
         self, model: str, messages: list, temperature: float = 0
     ):
@@ -138,7 +141,7 @@ class OpenAIWrapper:
             model=model, messages=messages, temperature=temperature
         )
 
-    @max_retries(3)
+    @max_retries(3, exceptions=OPENAI_EXCEPTIONS)
     def _call_edits_endpoint(self, model: str, input: str, instruction: str):
         """
         Call the edits endpoint from the OpenAI client and return response
@@ -155,7 +158,7 @@ class OpenAIWrapper:
 
         return openai.Edit.create(model=model, input=input, instruction=instruction)
 
-    @max_retries(3)
+    @max_retries(3, exceptions=OPENAI_EXCEPTIONS)
     def _call_embedding_endpoint(self, model: str, texts: List[str]):
         """
         Call the embedding endpoint from the OpenAI client and return response

--- a/llm_gateway/utils.py
+++ b/llm_gateway/utils.py
@@ -1,16 +1,23 @@
 import logging
 
+from openai.error import Timeout, APIError, APIConnectionError, RateLimitError
+
 level = logging.INFO
 logging.basicConfig(level=level)
 logger = logging.getLogger(__name__)
 
 
-def max_retries(times: int):
+DEFAULT_EXCEPTIONS = [Timeout, APIError, APIConnectionError, RateLimitError]
+
+
+def max_retries(times: int, exceptions: list = DEFAULT_EXCEPTIONS):
     """
     Max Retry Decorator
     Retries the wrapped function/method `times` times
     :param times: The max number of times to repeat the wrapped function/method
     :type times: int
+    :param Exceptions: Lists of exceptions that trigger a retry attempt
+    :type Exceptions: List of Exceptions    
     """
 
     def decorator(func):
@@ -19,7 +26,7 @@ def max_retries(times: int):
             while attempt < times:
                 try:
                     return func(*args, **kwargs)
-                except Exception as e:
+                except exceptions as e:
                     logger.error(
                         f"Exception '{e}' thrown when running '{func}'"
                         + f"(attempt {attempt} of {times} times)"

--- a/llm_gateway/utils.py
+++ b/llm_gateway/utils.py
@@ -1,16 +1,12 @@
 import logging
 
-from openai.error import Timeout, APIError, APIConnectionError, RateLimitError
 
 level = logging.INFO
 logging.basicConfig(level=level)
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_EXCEPTIONS = [Timeout, APIError, APIConnectionError, RateLimitError]
-
-
-def max_retries(times: int, exceptions: list = DEFAULT_EXCEPTIONS):
+def max_retries(times: int, exceptions: list = [Exceptions]):
     """
     Max Retry Decorator
     Retries the wrapped function/method `times` times

--- a/llm_gateway/utils.py
+++ b/llm_gateway/utils.py
@@ -6,7 +6,7 @@ logging.basicConfig(level=level)
 logger = logging.getLogger(__name__)
 
 
-def max_retries(times: int, exceptions: list = [Exceptions]):
+def max_retries(times: int, exceptions: list = [Exception]):
     """
     Max Retry Decorator
     Retries the wrapped function/method `times` times


### PR DESCRIPTION
**Why is this change being made?**
<!-- Short description of the motivation behind the change, including links to any relevant issues. -->

The current logic retries for all exceptions when you should only retry on server-side issues. 

**What is changing?**
<!-- Short technical summary of the changes made to the code. -->

Only retry for `Timeout, APIError, APIConnectionError, RateLimitError`

**How did I test?**
<!-- Short description of how the PR was tested, clear enough for reviewers to replicate.
     Where possible, add screenshots of the changed feature/functionality before and after your change.
-->

**Next steps and references**
<!-- Add any other context about follow-up PRs or related PRs here. -->
