### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ If using Docker, steps 1-3 are optional. We recommend installing pre-commit hook
 
 1. Install Poetry and Pyenv
 2. Install `pyenv install 3.11.3`
-3. Install project requirments
+3. Install project requirements
 ```
 brew install gitleaks
 poetry install


### PR DESCRIPTION
**Why is this change being made?**
There was a typo in the `README.md`

**What is changing?**
Change `requirments` to `requirements` in `README.md`

**How did I test?**
-

**Next steps and references**
-
