### PR TITLE
Fix retry decorator exception handling logic

### DIFF
--- a/llm_gateway/providers/openai.py
+++ b/llm_gateway/providers/openai.py
@@ -30,7 +30,7 @@ from llm_gateway.utils import max_retries
 
 from openai.error import Timeout, APIError, APIConnectionError, TryAgain
 
-OPENAI_EXCEPTIONS = [Timeout, APIError, APIConnectionError, TryAgain]
+OPENAI_EXCEPTIONS = (Timeout, APIError, APIConnectionError, TryAgain)
 SUPPORTED_OPENAI_ENDPOINTS = {
     "Model": ["list", "retrieve"],
     "ChatCompletion": ["create"],

--- a/llm_gateway/utils.py
+++ b/llm_gateway/utils.py
@@ -5,7 +5,7 @@ logging.basicConfig(level=level)
 logger = logging.getLogger(__name__)
 
 
-def max_retries(times: int, exceptions: tuple = (Exception)):
+def max_retries(times: int, exceptions: tuple = (Exception,)):
     """
     Max Retry Decorator
     Retries the wrapped function/method `times` times

--- a/llm_gateway/utils.py
+++ b/llm_gateway/utils.py
@@ -21,7 +21,9 @@ def max_retries(times: int, exceptions: list = [Exception]):
             while attempt < times:
                 try:
                     return func(*args, **kwargs)
-                except exceptions as e:
+                except Exception as e:
+                    if type(e) not in exceptions:
+                        raise e
                     logger.error(
                         f"Exception '{e}' thrown when running '{func}'"
                         + f"(attempt {attempt} of {times} times)"

--- a/llm_gateway/utils.py
+++ b/llm_gateway/utils.py
@@ -5,7 +5,7 @@ logging.basicConfig(level=level)
 logger = logging.getLogger(__name__)
 
 
-def max_retries(times: int, exceptions: list = [Exception]):
+def max_retries(times: int, exceptions: tuple = (Exception)):
     """
     Max Retry Decorator
     Retries the wrapped function/method `times` times
@@ -21,9 +21,7 @@ def max_retries(times: int, exceptions: list = [Exception]):
             while attempt < times:
                 try:
                     return func(*args, **kwargs)
-                except Exception as e:
-                    if type(e) not in exceptions:
-                        raise e
+                except exceptions as e:
                     logger.error(
                         f"Exception '{e}' thrown when running '{func}'"
                         + f"(attempt {attempt} of {times} times)"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,12 +10,12 @@ def test_retry_decorator():
     retry_mock.side_effect = [APIError("test"), "success"]
 
     ## Mismatch retry exception
-    @max_retries(1, exceptions=(ValueError))
+    @max_retries(1, exceptions=(ValueError,))
     def mismatch_exception():
         return retry_mock()
 
     ## Matching retry exception
-    @max_retries(1, exceptions=(APIError))
+    @max_retries(1, exceptions=(APIError,))
     def matching_exception():
         return retry_mock()
     

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,29 @@
+from unittest.mock import Mock
+
+import pytest
+from llm_gateway.utils import max_retries
+from openai.error import APIError
+
+
+def test_retry_decorator():
+
+    @max_retries(3)
+    def normal_exception():
+        raise Exception("test")
+
+    retry_mock = Mock()
+
+    retry_mock.side_effect = [APIError("test"), "success"]
+
+    @max_retries(3, exceptions=[APIError])
+    def openai_exception():
+        result = retry_mock()
+        if isinstance(result, str):
+            return result
+        else:
+            raise result
+    
+    with pytest.raises(Exception):
+        normal_exception()
+
+    assert openai_exception() == "success"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,24 +6,20 @@ from openai.error import APIError
 
 
 def test_retry_decorator():
-
-    @max_retries(3)
-    def normal_exception():
-        raise Exception("test")
-
     retry_mock = Mock()
-
     retry_mock.side_effect = [APIError("test"), "success"]
 
-    @max_retries(3, exceptions=[APIError])
+    ## Mismatch retry exception
+    @max_retries(1, exceptions=(ValueError))
+    def normal_exception():
+        return retry_mock()
+
+    ## Matching retry exception
+    @max_retries(1, exceptions=(APIError))
     def openai_exception():
-        result = retry_mock()
-        if isinstance(result, str):
-            return result
-        else:
-            raise result
+        return retry_mock()
     
-    with pytest.raises(Exception):
+    with pytest.raises(APIError):
         normal_exception()
 
     assert openai_exception() == "success"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,15 +11,15 @@ def test_retry_decorator():
 
     ## Mismatch retry exception
     @max_retries(1, exceptions=(ValueError))
-    def normal_exception():
+    def mismatch_exception():
         return retry_mock()
 
     ## Matching retry exception
     @max_retries(1, exceptions=(APIError))
-    def openai_exception():
+    def matching_exception():
         return retry_mock()
     
     with pytest.raises(APIError):
-        normal_exception()
+        mismatch_exception()
 
-    assert openai_exception() == "success"
+    assert matching_exception() == "success"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,21 +5,25 @@ from llm_gateway.utils import max_retries
 from openai.error import APIError
 
 
-def test_retry_decorator():
+def test_retry_decorator_mismatch_exception():
     retry_mock = Mock()
     retry_mock.side_effect = [APIError("test"), "success"]
 
-    ## Mismatch retry exception
     @max_retries(1, exceptions=(ValueError,))
     def mismatch_exception():
         return retry_mock()
+    
+    with pytest.raises(APIError):
+        mismatch_exception()
+
+
+def test_retry_decorator_matching_exception():
+    retry_mock = Mock()
+    retry_mock.side_effect = [APIError("test"), "success"]
 
     ## Matching retry exception
     @max_retries(1, exceptions=(APIError,))
     def matching_exception():
         return retry_mock()
-    
-    with pytest.raises(APIError):
-        mismatch_exception()
 
     assert matching_exception() == "success"


### PR DESCRIPTION
**Why is this change being made?**
The previous change to the retry logic is catching exceptions incorrectly.

Python can't catch a list of exception

**What is changing?**
Catch the exception and checking if it is in the list of exceptions to exempt.

**How did I test?**
- Added a test case
- run the service and test with the following
```
curl -X 'POST' \
  'http://localhost:5000/api/openai/completion' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "temperature": 0,
  "prompt": "bark like a dog",
  "max_tokens": 50,
  "model": "this-model-does-not-exist",
  "model_kwargs": {}
}'
```
