### PR TITLE
fix issue with user messages not being formated

### DIFF
--- a/front_end/public/styles.css
+++ b/front_end/public/styles.css
@@ -41,6 +41,7 @@
   max-width: 85%;
   width: fit-content;
   list-style-type: none;
+  white-space: pre-wrap;
 }
 
 .message-user {


### PR DESCRIPTION
**Why is this change being made?**
User messages were not formated correctly, newlines and whitespaces were collapsed

**What is changing?**
preserve whitespace and newlines are broken at "\n"

<img width="1308" alt="Screenshot 2023-08-21 at 3 58 53 PM" src="https://github.com/wealthsimple/llm-gateway/assets/74056617/87377456-9e00-467d-bd23-edc1b3318967">

