### PR TITLE
Fix frontend darkmode styling

### DIFF
--- a/front_end/public/styles.css
+++ b/front_end/public/styles.css
@@ -102,7 +102,6 @@
 }
 
 .confirmation-content {
-  background-color: #fff;
   padding: 20px;
   border-radius: 5px;
   text-align: center;

--- a/front_end/public/styles.css
+++ b/front_end/public/styles.css
@@ -59,6 +59,9 @@
   margin-right: auto;
   margin-left: 8px;
   background-color: #f1f0f0;
+}
+
+.message p, li {
   color: #1c1b1b;
 }
 

--- a/front_end/src/app/components/ChatBox/ClearButton.tsx
+++ b/front_end/src/app/components/ChatBox/ClearButton.tsx
@@ -48,7 +48,7 @@ export const ClearButton: React.FC<ClearButtonProps> = ({ onClear }) => {
 
       {showConfirmationDialog && (
         <div className="confirmation-modal">
-          <div className="confirmation-content">
+          <article className="confirmation-content">
             <h2>Confirmation</h2>
             <p>Are you sure you want to clear the conversation?</p>
             <div className="confirmation-buttons">
@@ -59,7 +59,7 @@ export const ClearButton: React.FC<ClearButtonProps> = ({ onClear }) => {
                 No
               </button>
             </div>
-          </div>
+          </article>
         </div>
       )}
     </>


### PR DESCRIPTION
**Why is this change being made?**
I was looking at the frontend app in dark mode and noticed that the text colour of the "Clear Conversation" modal was a little while making it hard to read. After playing around with the frontend by entering some prompts I also noticed that the text in some of the assistant responses was also hard to read as the text color was white. 

I discovered that Pico CSS, one of the libraries, has a preset style enforced. The background color would be white and text color is black in light mode. The background color would black and text color would be white. This caused an issue with modal as the background color was set to white in the CSS. For the text colors in the chat, I noticed that it was only affecting responses that were converted to markdown. The markdown renders as HTML elements and Pico would automatically apply styling to them.

**What is changing?**
I removed the background color for the modal set in the CSS and changed the `confirmation-content` div in `ClearButton` to an `article` which is a Pico CSS Card component. It will automatically set the background color for the modal depending on the mode.

I added a CSS style for the message class forcing the text color to be black regardless of light mode or dark mode.

**How did I test?**
I ran the frontend in both light mode and dark mode checking out the modal and trying the following prompts:
* entering a prompt that gives an example of code
* entering a prompt that will generate a list
* entering a prompt that will give a multiline response

"Clear conversation" modal
Before: 
![before_clear](https://github.com/wealthsimple/llm-gateway/assets/60418739/02650145-b50b-4cb7-b561-2a51c1003640)

After:
![after_clear](https://github.com/wealthsimple/llm-gateway/assets/60418739/a2006424-e7e8-401a-b260-b6baad166f11)

multiline response from assistant
Before: 
![before_multiline](https://github.com/wealthsimple/llm-gateway/assets/60418739/2fea2fcb-57ed-4245-a610-1174f7e989ad)

After:
![after_multiline](https://github.com/wealthsimple/llm-gateway/assets/60418739/eef272ff-49eb-4285-bbfb-c86e875c3beb)

code response from assistant
Before:
![before_code](https://github.com/wealthsimple/llm-gateway/assets/60418739/56896ac7-6e08-4aed-a9a6-f102164abe73)

After:
![after_code](https://github.com/wealthsimple/llm-gateway/assets/60418739/0f1dd097-3a57-42d4-a50c-83adcfb39653)

list response from assistant
Before:
![before_list](https://github.com/wealthsimple/llm-gateway/assets/60418739/de7c3223-2d7b-4730-9180-b1a4b80d7e1c)

After:
![after_list](https://github.com/wealthsimple/llm-gateway/assets/60418739/a7793d0c-2471-44a9-92f5-1ed6c59a83f6)

**Next steps and references**
