### PR TITLE
feat/exception handlers

### DIFF
--- a/front_end/src/services/apiService.tsx
+++ b/front_end/src/services/apiService.tsx
@@ -43,6 +43,11 @@ export async function fetchResponseFromModel(
     return res.data.choices[0].message.content;
   } catch (error) {
     const err = error as AxiosError;
+    const errResponse = err.response as AxiosResponse;
+
+    if (err.message && errResponse) {
+      throw new Error(`${err.message}: ${errResponse.data.error.message}`);
+    }
     if (err.message) {
       throw new Error(`${err.message}`);
     }

--- a/front_end/src/services/apiService.tsx
+++ b/front_end/src/services/apiService.tsx
@@ -43,10 +43,10 @@ export async function fetchResponseFromModel(
     return res.data.choices[0].message.content;
   } catch (error) {
     const err = error as AxiosError;
-    const errResponse = err.response as AxiosResponse;
+    const errRes = err.response as AxiosResponse;
 
-    if (err.message && errResponse) {
-      throw new Error(`${err.message}: ${errResponse.data.error.message}`);
+    if (err.message && errRes.data.error) {
+      throw new Error(`${err.message}: ${errRes.data.error}`);
     }
     if (err.message) {
       throw new Error(`${err.message}`);

--- a/llm_gateway/exceptions.py
+++ b/llm_gateway/exceptions.py
@@ -32,7 +32,7 @@ class OpenAIRouteExceptionHandler(APIRoute):
             try:
                 response = await original_route_handler(request)
             except OPENAI_EXCEPTIONS as e:
-                # print the exception to the console
+                # print exception traceback to console
                 print_exception(type(e), e, e.__traceback__)
                 response = JSONResponse(status_code=500, content={"error": str(e)})
             return response
@@ -62,7 +62,7 @@ class CohereRouteExceptionHandler(APIRoute):
             try:
                 response = await original_route_handler(request)
             except COHERE_EXCEPTIONS as e:
-                # print the exception to the console
+                # print exception traceback to console
                 print_exception(type(e), e, e.__traceback__)
                 response = JSONResponse(status_code=500, content={"error": str(e)})
             return response

--- a/llm_gateway/exceptions.py
+++ b/llm_gateway/exceptions.py
@@ -1,0 +1,30 @@
+from traceback import print_exception
+
+from fastapi.responses import JSONResponse
+from fastapi.routing import APIRoute
+from openai.error import APIConnectionError, APIError, RateLimitError, Timeout, TryAgain
+
+OPENAI_EXCEPTIONS = (Timeout, APIError, APIConnectionError, TryAgain, RateLimitError)
+
+
+class OpenAIRouteExceptionHandler(APIRoute):
+    """ """
+
+    def get_route_handler(self):
+        original_route_handler = super().get_route_handler()
+
+        async def exception_handler(request):
+            try:
+                response = await original_route_handler(request)
+            except OPENAI_EXCEPTIONS as e:
+                print_exception(type(e), e, e.__traceback__)
+                response = JSONResponse(
+                    status_code=500,
+                    content={"error": e.error},
+                )
+            return response
+
+        return exception_handler
+
+
+# # TODO : Implement Cohere Router Exception Handler

--- a/llm_gateway/exceptions.py
+++ b/llm_gateway/exceptions.py
@@ -1,30 +1,70 @@
 from traceback import print_exception
 
+from cohere.error import CohereAPIError, CohereConnectionError, CohereError
+from fastapi import Request
 from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute
 from openai.error import APIConnectionError, APIError, RateLimitError, Timeout, TryAgain
 
 OPENAI_EXCEPTIONS = (Timeout, APIError, APIConnectionError, TryAgain, RateLimitError)
+COHERE_EXCEPTIONS = (CohereError, CohereAPIError, CohereConnectionError)
 
 
 class OpenAIRouteExceptionHandler(APIRoute):
-    """ """
+    """
+    This is a route class override for the OpenAI router. It is used to
+    catch common exceptions that are raised by the OpenAI API and return an
+    internal server error response with its associated error message.
+    """
 
     def get_route_handler(self):
         original_route_handler = super().get_route_handler()
 
-        async def exception_handler(request):
+        async def exception_handler(request: Request) -> JSONResponse:
+            """
+            Catch OpenAI exceptions and return an internal server error response.
+
+            :param request: The request object
+            :type request: Request
+            :return: Internal server error response with error message
+            :rtype: JSONResponse
+            """
             try:
                 response = await original_route_handler(request)
             except OPENAI_EXCEPTIONS as e:
+                # print the exception to the console
                 print_exception(type(e), e, e.__traceback__)
-                response = JSONResponse(
-                    status_code=500,
-                    content={"error": e.error},
-                )
+                response = JSONResponse(status_code=500, content={"error": str(e)})
             return response
 
         return exception_handler
 
 
-# # TODO : Implement Cohere Router Exception Handler
+class CohereRouteExceptionHandler(APIRoute):
+    """
+    This is a route class override for the Cohere router. It is used to
+    catch common exceptions that are raised by the Cohere API and return an
+    internal server error response with its associated error message.
+    """
+
+    def get_route_handler(self):
+        original_route_handler = super().get_route_handler()
+
+        async def exception_handler(request: Request) -> JSONResponse:
+            """
+            Catch Cohere exceptions and return an internal server error response.
+
+            :param request: The request object
+            :type request: Request
+            :return: Internal server error response with error message
+            :rtype: JSONResponse
+            """
+            try:
+                response = await original_route_handler(request)
+            except COHERE_EXCEPTIONS as e:
+                # print the exception to the console
+                print_exception(type(e), e, e.__traceback__)
+                response = JSONResponse(status_code=500, content={"error": str(e)})
+            return response
+
+        return exception_handler

--- a/llm_gateway/providers/openai.py
+++ b/llm_gateway/providers/openai.py
@@ -22,15 +22,14 @@ import os
 from typing import List, Optional
 
 import openai
+from openai.error import APIConnectionError, APIError, RateLimitError, Timeout, TryAgain
 
 from llm_gateway.db.models import OpenAIRequests
 from llm_gateway.db.utils import write_record_to_db
 from llm_gateway.pii_scrubber import scrub_all
 from llm_gateway.utils import max_retries
 
-from openai.error import Timeout, APIError, APIConnectionError, TryAgain
-
-OPENAI_EXCEPTIONS = (Timeout, APIError, APIConnectionError, TryAgain)
+OPENAI_EXCEPTIONS = (Timeout, APIError, APIConnectionError, TryAgain, RateLimitError)
 SUPPORTED_OPENAI_ENDPOINTS = {
     "Model": ["list", "retrieve"],
     "ChatCompletion": ["create"],

--- a/llm_gateway/routers/cohere_api.py
+++ b/llm_gateway/routers/cohere_api.py
@@ -18,10 +18,11 @@
 from fastapi import APIRouter
 from starlette.responses import JSONResponse
 
+from llm_gateway.exceptions import CohereRouteExceptionHandler
 from llm_gateway.models import GenerateInput
 from llm_gateway.providers.cohere import CohereWrapper
 
-router = APIRouter()
+router = APIRouter(route_class=CohereRouteExceptionHandler)
 
 
 @router.post("/generate")

--- a/llm_gateway/routers/openai_api.py
+++ b/llm_gateway/routers/openai_api.py
@@ -18,6 +18,7 @@
 from fastapi import APIRouter
 from starlette.responses import JSONResponse
 
+from llm_gateway.exceptions import OpenAIRouteExceptionHandler
 from llm_gateway.models import (
     ChatCompletionInput,
     CompletionInput,
@@ -26,7 +27,7 @@ from llm_gateway.models import (
 )
 from llm_gateway.providers.openai import OpenAIWrapper
 
-router = APIRouter()
+router = APIRouter(route_class=OpenAIRouteExceptionHandler)
 
 
 @router.post("/completion")


### PR DESCRIPTION
**Why is this change being made?**

When an exception is raised within the backend the UI displays an error message "Request failed with status code 500". This message is consistent regardless of what the error being thrown is.

<details>
<summary>Error Message (current)</summary>
<br>
<image src="https://github.com/wealthsimple/llm-gateway/assets/87831908/138f6688-c67b-478f-bb1e-2af9fcdcdb87' alt="emo"/>
</details>

The only way to see the issue is by reading the console traceback when the exception is thrown:

<details>
<summary>Console Traceback (current)</summary>
<br>
<image src="https://github.com/wealthsimple/llm-gateway/assets/87831908/321353cf-8e2b-46cf-aae2-67abdec698ff" alt="cto"/>
</details>

**What is changing?**

An additional file `exceptions.py` is added to override the OpenAI and Cohere Routers within the backend, adding a custom exception handler for common OpenAI API and Cohere API exceptions. The exception handlers catch the raised errors and pass the exception message within the JSONresponse object so that they can be displayed within the UI and provide greater insight on the error being thrown. They also still propagate the error traceback within the console.

<details>
<summary>Error Message (new)</summary>
<br>
<image src="https://github.com/wealthsimple/llm-gateway/assets/87831908/ebd0533c-04cc-4066-a39b-c462b8c42fa9" alt="emn"/>
</details>

<details>
<summary>Console Traceback (new)</summary>
<br>
<image src="https://github.com/wealthsimple/llm-gateway/assets/87831908/ecd5d67e-a778-47b4-8e8c-bd4c622747b7" alt="ctn"/>
</details>

**How did I test?**

Screenshots from before and after are within the drop-downs above.

The application still works with no issues when a valid api key is used.

<details>
<summary>No Issues</summary>
<br>
<image src="https://github.com/wealthsimple/llm-gateway/assets/87831908/1f200983-832d-4078-afe7-c12f4740f927" alt="wrk" />
</details>

The code has been tested manually with both an OpenAI api key containing a valid balance and an OpenAI api key containing a null balance (test errors). 

**Next steps and references**

N/A