### PR TITLE
Feat/aws bedrock

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -2,4 +2,8 @@ export OPENAI_API_KEY=
 export COHERE_API_KEY=
 export EXTRA_RUN_OPTIONS=--reload
 
+export AWS_REGION=
+export AWS_PUBLIC_ACCESS_KEY=
+export AWS_PRIVATE_ACCESS_KEY=
+
 export DATABASE_URL=postgresql://postgres:postgres@postgres:5432/llm_gateway

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Use `llm-gateway` to interact with OpenAI in a safe manner. The gateway also rec
 
 The provider's API key needs to be saved as an environment variable (see setup further down). If you are communicating with OpenAI, set `OPENAI_API_KEY`.
 
+For step-by-step setup instructions with Cohere, OpenAI, and AWS Bedrock, click [here](llm_gateway/README.md).
+
 ### API Usage
 [OpenAI] Example cURL to `/completion` endpoint:
 ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Use `llm-gateway` to interact with OpenAI in a safe manner. The gateway also rec
 | Meta          | Llama-2-13b-chat          |
 | Meta          | Llama-2-70b-chat          |
 
-
 ## ⚒️ Usage
 
 The provider's API key needs to be saved as an environment variable (see setup further down). If you are communicating with OpenAI, set `OPENAI_API_KEY`.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,30 @@ Per OpenAI's non-API consumer products [data usage policy](https://help.openai.c
 
 Use `llm-gateway` to interact with OpenAI in a safe manner. The gateway also recreates the ChatGPT frontend using OpenAI's `/ChatCompletion` endpoint to keep all communication within the API.
 
+## 📦 Supported Models
+
+| Provider      | Model                     |
+|:--------------:|:-------------------------:|
+| OpenAI        | GPT 3.5 Turbo             |
+| OpenAI        | GPT 3.5 Turbo 16k         |
+| OpenAI        | GPT 4                     |
+| AI21 Labs     | Jurassic-2 Ultra          |
+| AI21 Labs     | Jurassic-2 Mid            |
+| Amazon        | Titan Text Lite           |
+| Amazon        | Titan Text Express        |
+| Amazon        | Titan Text Embeddings     |
+| Anthropic     | Claude 2.1                |
+| Anthropic     | Claude 2.0                |
+| Anthropic     | Claude 1.3                |
+| Anthropic     | Claude Instant            |
+| Cohere        | Command                   |
+| Cohere        | Command Light             |
+| Cohere        | Embed - English           |
+| Cohere        | Embed - Multilingual      |
+| Meta          | Llama-2-13b-chat          |
+| Meta          | Llama-2-70b-chat          |
+
+
 ## ⚒️ Usage
 
 The provider's API key needs to be saved as an environment variable (see setup further down). If you are communicating with OpenAI, set `OPENAI_API_KEY`.

--- a/fixtures/init.sql
+++ b/fixtures/init.sql
@@ -21,3 +21,15 @@ CREATE TABLE cohere_requests(
     created_at TIMESTAMP WITHOUT TIME ZONE,
     cohere_endpoint VARCHAR
 );
+
+CREATE TABLE awsbedrock_requests(
+    id serial primary key,
+    user_input VARCHAR,
+    user_email VARCHAR,
+    awsbedrock_response JSON,
+    awsbedrock_model VARCHAR,
+    temperature FLOAT,
+    created_at TIMESTAMP WITHOUT TIME ZONE,
+    awsbedrock_endpoint VARCHAR
+    extras JSON
+);

--- a/front_end/src/app/components/SettingsDialog/settingsDialog.tsx
+++ b/front_end/src/app/components/SettingsDialog/settingsDialog.tsx
@@ -122,6 +122,15 @@ export const ModelSettingsDialog: React.FC<Props> = ({
                 </b>
                 {modelChoices[selectedOption].maxTokensLimit} tokens <br />
               </li>
+              <li>
+                <b>
+                  <span role="img" aria-label="blink">
+                    ⚙️
+                  </span>{' '}
+                  Requirements:{' '}
+                </b>
+                {modelChoices[selectedOption].requirements} <br />
+              </li>
             </ul>
           </details>
           <details>

--- a/front_end/src/app/interfaces.tsx
+++ b/front_end/src/app/interfaces.tsx
@@ -68,10 +68,10 @@ export interface AWSBedrockRequestBody {
   model: string;
   temperature: number;
   max_tokens: number;
-  prompt: string;
+  prompt?: string;
   embedding_texts?: string[];
   instructions?: string;
-  kwargs?: ModelConfig;
+  model_kwargs?: ModelConfig;
 }
 
 interface ModelMetadata {

--- a/front_end/src/app/interfaces.tsx
+++ b/front_end/src/app/interfaces.tsx
@@ -68,9 +68,9 @@ export interface AWSBedrockRequestBody {
   model: string;
   temperature: number;
   max_tokens: number;
-  prompt?: string;
-  messages?: Message[];
+  prompt: string;
   embedding_texts?: string[];
+  instructions?: string;
   kwargs?: ModelConfig;
 }
 

--- a/front_end/src/app/interfaces.tsx
+++ b/front_end/src/app/interfaces.tsx
@@ -46,7 +46,8 @@ export interface ModelInfo {
   advanceMetadata: ModelMetadata;
   supportFileUpload: boolean;
   initialPrompt: Message[];
-  requestBody: (req: IRequestBody) => OpenAIRequestBody | CohereRequestBody;
+  requirements: string,
+  requestBody: (req: IRequestBody) => OpenAIRequestBody | CohereRequestBody | AWSBedrockRequestBody;
   responseHandler: (res: any) => string;
 }
 
@@ -63,8 +64,22 @@ export interface CohereRequestBody {
   model: string;
 }
 
+export interface AWSBedrockRequestBody {
+  model: string;
+  temperature: number;
+  max_tokens: number;
+  prompt?: string;
+  messages?: Message[];
+  embedding_texts?: string[];
+  kwargs?: ModelConfig;
+}
+
 interface ModelMetadata {
   [key: string]: string;
+}
+
+interface ModelConfig {
+  [key: string]: any;
 }
 
 export interface Models {

--- a/front_end/src/constants.tsx
+++ b/front_end/src/constants.tsx
@@ -67,22 +67,12 @@ const AWSBedrockTitanTextParseResponse = (response: any) => {
   return response.results[0].outputText;
 }
 
-const AWSBedrockTitanEmbedParseResponse = (response: any) => {
-  // return response with new line character between each vector point
-  return (response.embedding as string[]).map((value: string) => value + "\n").join('');
-}
-
 const AWSBedrockClaudeTextParseResponse = (response: any) => {
   return response.completion;
 }
 
 const AWSBedrockCohereTextParseResponse = (response: any) => {
   return response.generations[0].text;
-}
-
-const AWSBedrockCohereEmbedParseResponse = (response: any) => {
-  // return response with new line character between each vector point
-  return (response.embeddings[0] as string[]).map((value: string) => value + "\n").join('');
 }
 
 
@@ -198,7 +188,7 @@ export const modelChoices: Models = {
     description:
       'Fine-tuned model in the parameter size of 13B. Suitable for smaller-scale tasks such as text classification, sentiment analysis, and language translation.',
     initialPrompt: DEFAULT_INITIAL_PROMPT,
-    maxTokensLimit: 4000,
+    maxTokensLimit: 4096,
     isSecureModel: false,
     supportFileUpload: false,
     requirements: "AWS Account + Bedrock Enabled",
@@ -211,7 +201,7 @@ export const modelChoices: Models = {
       ({
         prompt: req.messages.at(-1)?.content,
         model: 'meta.llama2-13b-chat-v1',
-        max_tokens: 4000, // TODO : add model config dialog to remove hardcoded values (i.e max_tokens, temperature, model_kwargs)
+        max_tokens: 500, // TODO : add model config dialog to remove hardcoded values (i.e max_tokens, temperature, model_kwargs)
         temperature: req.temperature,
         instructions: DEFAULT_INITIAL_PROMPT[0].content,
         model_kwargs: {
@@ -227,7 +217,7 @@ export const modelChoices: Models = {
     description:
       'Fine-tuned model in the parameter size of 70B. Suitable for larger-scale tasks such as language modeling, text generation, and dialogue systems.',
     initialPrompt: DEFAULT_INITIAL_PROMPT,
-    maxTokensLimit: 4000,
+    maxTokensLimit: 4096,
     isSecureModel: false,
     supportFileUpload: false,
     requirements: "AWS Account + Bedrock Enabled",
@@ -240,7 +230,7 @@ export const modelChoices: Models = {
       ({
         prompt: req.messages.at(-1)?.content,
         model: 'meta.llama2-70b-chat-v1',
-        max_tokens: 4000,
+        max_tokens: 500,
         temperature: req.temperature,
         instruction: DEFAULT_INITIAL_PROMPT[0].content,
         model_kwargs: {
@@ -269,7 +259,7 @@ export const modelChoices: Models = {
       ({
         prompt: req.messages.at(-1)?.content,
         model: 'ai21.j2-mid-v1',
-        max_tokens: 8192,
+        max_tokens: 4096,
         temperature: req.temperature,
         model_kwargs: {
           "topP": 1,
@@ -306,7 +296,7 @@ export const modelChoices: Models = {
       ({
         prompt: req.messages.at(-1)?.content,
         model: 'ai21.j2-ultra-v1',
-        max_tokens: 8192,
+        max_tokens: 4096,
         temperature: req.temperature,
         model_kwargs: {
           "topP": 1,
@@ -343,7 +333,7 @@ export const modelChoices: Models = {
       ({
         prompt: req.messages.at(-1)?.content,
         model: 'amazon.titan-text-lite-v1',
-        max_tokens: 4000,
+        max_tokens: 2000,
         temperature: req.temperature,
         model_kwargs: {
           "stopSequences": [],
@@ -372,7 +362,7 @@ export const modelChoices: Models = {
       ({
         prompt: req.messages.at(-1)?.content,
         model: 'amazon.titan-text-express-v1',
-        max_tokens: 8000,
+        max_tokens: 4000,
         temperature: req.temperature,
         model_kwargs: {
           "stopSequences": [],
@@ -380,30 +370,6 @@ export const modelChoices: Models = {
         }
       } as AWSBedrockRequestBody),
     responseHandler: AWSBedrockTitanTextParseResponse,
-  },
-  amazon_titan_embed: {
-    name: 'Titan Embeddings',
-    distributor: 'Amazon',
-    apiEndpoint: `${appEnv.apiBaseURL}/api/awsbedrock/embed`,
-    description:
-      'LLM that translates text into numerical representations.',
-    initialPrompt: DEFAULT_INITIAL_PROMPT,
-    maxTokensLimit: 8000,
-    isSecureModel: false,
-    supportFileUpload: false,
-    requirements: "AWS Account + Bedrock Enabled",
-    advanceMetadata: {
-      'Hosted on': 'Amazon Web Services (Bedrock)',
-      'Inference Hardware': 'GPU',
-      'Embeddings': '1536',
-    },
-    requestBody: (req: IRequestBody) =>
-      ({
-        embedding_texts: [req.messages.at(-1)?.content],
-        model: 'amazon.titan-embed-text-v1',
-        max_tokens: 8000,
-      } as AWSBedrockRequestBody),
-    responseHandler: AWSBedrockTitanEmbedParseResponse,
   },
   anthropic_claude_v1: {
     name: 'Claude 1.3',
@@ -425,7 +391,7 @@ export const modelChoices: Models = {
       ({
         prompt: req.messages.at(-1)?.content,
         model: 'anthropic.claude-v1',
-        max_tokens: 100000,
+        max_tokens: 500,
         temperature: req.temperature,
         model_kwargs: {
           "top_k": 250,
@@ -563,85 +529,6 @@ export const modelChoices: Models = {
         }
       } as AWSBedrockRequestBody),
     responseHandler: AWSBedrockCohereTextParseResponse,
-  },
-  cohere_command_light_v14: {
-    name: 'Command Light',
-    distributor: 'Cohere',
-    apiEndpoint: `${appEnv.apiBaseURL}/api/awsbedrock/text`,
-    description:
-      'Command Light is a smaller version of Command, Cohere\'s generative LLM (6B parameters).',
-    initialPrompt: DEFAULT_INITIAL_PROMPT,
-    maxTokensLimit: 4000,
-    isSecureModel: false,
-    supportFileUpload: false,
-    requirements: "AWS Account + Bedrock Enabled",
-    advanceMetadata: {
-      'Hosted on': 'Amazon Web Services (Bedrock)',
-      'Inference Hardware': 'GPU',
-      'Context window': '4k',
-    },
-    requestBody: (req: IRequestBody) =>
-      ({
-        prompt: req.messages.at(-1)?.content,
-        model: 'cohere.command-light-text-v14',
-        max_tokens: 4000,
-        temperature: req.temperature,
-        model_kwargs: {
-          "p": 0.75,
-          "k": 0,
-          "stop_sequences": [],
-          "return_likelihoods": "NONE"
-        }
-      } as AWSBedrockRequestBody),
-      responseHandler: AWSBedrockCohereTextParseResponse,
-    },
-  cohere_embed_english_v3: {
-    name: 'Embed (English)',
-    distributor: 'Cohere',
-    apiEndpoint: `${appEnv.apiBaseURL}/api/awsbedrock/embed`,
-    description:
-      'Embed is Cohere\'s text representation, or embeddings, model. This version supports English only.',
-    initialPrompt: DEFAULT_INITIAL_PROMPT,
-    maxTokensLimit: 1024,
-    isSecureModel: false,
-    supportFileUpload: false,
-    requirements: "AWS Account + Bedrock Enabled",
-    advanceMetadata: {
-      'Hosted on': 'Amazon Web Services (Bedrock)',
-      'Inference Hardware': 'GPU',
-      'Context window': '4k',
-    },
-    requestBody: (req: IRequestBody) =>
-      ({
-        embedding_texts: [req.messages.at(-1)?.content],
-        model: 'cohere.embed-english-v3',
-        max_tokens: 1024,
-      } as AWSBedrockRequestBody),
-      responseHandler: AWSBedrockCohereEmbedParseResponse,
-    },
-  cohere_embed_multilingual_v3: {
-    name: 'Embed (Multilingual)',
-    distributor: 'Cohere',
-    apiEndpoint: `${appEnv.apiBaseURL}/api/awsbedrock/embed`,
-    description:
-      'Embed is Cohere\'s text representation, or embeddings, model. This version supports multiple languages.',
-    initialPrompt: DEFAULT_INITIAL_PROMPT,
-    maxTokensLimit: 1024,
-    isSecureModel: false,
-    supportFileUpload: false,
-    requirements: "AWS Account + Bedrock Enabled",
-    advanceMetadata: {
-      'Hosted on': 'Amazon Web Services (Bedrock)',
-      'Inference Hardware': 'GPU',
-      'Context window': '4k',
-    },
-    requestBody: (req: IRequestBody) =>
-      ({
-        embedding_texts: [req.messages.at(-1)?.content],
-        model: 'cohere.embed-multilingual-v3',
-        max_tokens: 1024,
-      } as AWSBedrockRequestBody),
-      responseHandler: AWSBedrockCohereEmbedParseResponse,
   },
 };
 

--- a/front_end/src/constants.tsx
+++ b/front_end/src/constants.tsx
@@ -25,6 +25,7 @@ import {
   type CohereRequestBody,
   type Settings,
   type ConversationsState,
+  type AWSBedrockRequestBody,
 } from './app/interfaces';
 
 import { environment as PROD_ENV } from './environments/environment.prod';
@@ -61,6 +62,7 @@ const DEFAULT_INITIAL_PROMPT = [
 ];
 
 export const modelChoices: Models = {
+  // Cohere models
   cohere: {
     name: 'Cohere - command-light',
     distributor: 'Cohere',
@@ -70,6 +72,7 @@ export const modelChoices: Models = {
     maxTokensLimit: 4096,
     isSecureModel: false,
     supportFileUpload: false,
+    requirements: "Cohere Account",
     advanceMetadata: {
       'Hosted on': 'Cohere Cloud',
       'Inference Hardware': 'GPU',
@@ -85,6 +88,7 @@ export const modelChoices: Models = {
       } as CohereRequestBody),
     responseHandler: CohereParseResponse,
   },
+  // OpenAI models
   gpt_3_5_turbo: {
     name: 'GPT 3.5 Turbo',
     distributor: 'OpenAI',
@@ -94,6 +98,7 @@ export const modelChoices: Models = {
     maxTokensLimit: 4096,
     isSecureModel: false,
     supportFileUpload: false,
+    requirements: "OpenAI Account",
     advanceMetadata: {
       'Hosted on': 'OpenAI Cloud',
       'Inference Hardware': 'GPU',
@@ -117,6 +122,7 @@ export const modelChoices: Models = {
     maxTokensLimit: 16384,
     isSecureModel: false,
     supportFileUpload: false,
+    requirements: "OpenAI Account",
     advanceMetadata: {
       'Hosted on': 'OpenAI Cloud',
       'Context window': '16k',
@@ -139,6 +145,7 @@ export const modelChoices: Models = {
     maxTokensLimit: 8192,
     isSecureModel: false,
     supportFileUpload: false,
+    requirements: "OpenAI Account",
     advanceMetadata: {
       'Hosted on': 'OpenAI Cloud',
       'Inference Hardware': 'GPU',
@@ -150,6 +157,545 @@ export const modelChoices: Models = {
         model: 'gpt-4',
         temperature: req.temperature,
       } as OpenAIRequestBody),
+    responseHandler: OpenAIParseResponse,
+  },
+  // AWS Bedrock models
+  meta_llama2_13b: {
+    name: 'Llama 2 13B',
+    distributor: 'Meta',
+    apiEndpoint: `${appEnv.apiBaseURL}/api/awsbedrock/chat`,
+    description:
+      'Fine-tuned model in the parameter size of 13B. Suitable for smaller-scale tasks such as text classification, sentiment analysis, and language translation.',
+    initialPrompt: DEFAULT_INITIAL_PROMPT,
+    maxTokensLimit: 4000,
+    isSecureModel: false,
+    supportFileUpload: false,
+    requirements: "AWS Account + Bedrock Enabled",
+    advanceMetadata: {
+      'Hosted on': 'Amazon Web Services (Bedrock)',
+      'Inference Hardware': 'GPU',
+      'Context window': '4k',
+    },
+    requestBody: (req: IRequestBody) =>
+      ({
+        messages: req.messages,
+        model: 'meta.llama2-13b-chat-v1',
+        max_tokens: 500, // TODO : add model config dialog to remove hardcoded values (i.e max_tokens, temperature, kwargs)
+        temperature: req.temperature,
+        kwargs: {
+          "top_p": 0.9
+        },
+      } as AWSBedrockRequestBody),
+    responseHandler: OpenAIParseResponse,
+  },
+  meta_llama2_70b: {
+    name: 'Llama 2 70B',
+    distributor: 'Meta',
+    apiEndpoint: `${appEnv.apiBaseURL}/api/awsbedrock/chat`,
+    description:
+      'Fine-tuned model in the parameter size of 70B. Suitable for larger-scale tasks such as language modeling, text generation, and dialogue systems.',
+    initialPrompt: DEFAULT_INITIAL_PROMPT,
+    maxTokensLimit: 4000,
+    isSecureModel: false,
+    supportFileUpload: false,
+    requirements: "AWS Account + Bedrock Enabled",
+    advanceMetadata: {
+      'Hosted on': 'Amazon Web Services (Bedrock)',
+      'Inference Hardware': 'GPU',
+      'Context window': '4k',
+    },
+    requestBody: (req: IRequestBody) =>
+      ({
+        messages: req.messages,
+        model: 'meta.llama2-70b-chat-v1',
+        max_tokens: 500,
+        temperature: req.temperature,
+        kwargs: {
+          "top_p": 0.9
+        },
+      } as AWSBedrockRequestBody),
+    responseHandler: OpenAIParseResponse,
+  }, 
+  ai21_jurassic2_mid: {
+    name: 'Jurassic2 Mid',
+    distributor: 'AI21 Labs',
+    apiEndpoint: `${appEnv.apiBaseURL}/api/awsbedrock/text`,
+    description:
+      'AI21\'s mid-sized model, designed to strike the right balance between exceptional quality and affordability.',
+    initialPrompt: DEFAULT_INITIAL_PROMPT,
+    maxTokensLimit: 8192,
+    isSecureModel: false,
+    supportFileUpload: false,
+    requirements: "AWS Account + Bedrock Enabled",
+    advanceMetadata: {
+      'Hosted on': 'Amazon Web Services (Bedrock)',
+      'Inference Hardware': 'GPU',
+      'Context window': '8k',
+    },
+    requestBody: (req: IRequestBody) =>
+      ({
+        prompt: req.messages.at(-1)?.content,
+        model: 'ai21.j2-mid-v1',
+        max_tokens: 500,
+        temperature: req.temperature,
+        kwargs: {
+          "topP":250,
+          "stop_sequences":[],
+          "countPenalty":{
+            "scale":0
+          },
+          "presencePenalty":{
+            "scale":0
+          },
+          "frequencyPenalty":{
+            "scale":0
+          }
+        }
+      } as AWSBedrockRequestBody),
+    responseHandler: OpenAIParseResponse,
+  },
+  ai21_jurrasic2_ultra: {
+    name: 'Jurassic2 Ultra',
+    distributor: 'AI21 Labs',
+    apiEndpoint: `${appEnv.apiBaseURL}/api/awsbedrock/text`,
+    description:
+      'AI21\'s most powerful model, offering exceptional quality.',
+    initialPrompt: DEFAULT_INITIAL_PROMPT,
+    maxTokensLimit: 8192,
+    isSecureModel: false,
+    supportFileUpload: false,
+    requirements: "AWS Account + Bedrock Enabled",
+    advanceMetadata: {
+      'Hosted on': 'Amazon Web Services (Bedrock)',
+      'Inference Hardware': 'GPU',
+      'Context window': '8k',
+    },
+    requestBody: (req: IRequestBody) =>
+      ({
+        prompt: req.messages.at(-1)?.content,
+        model: 'ai21.j2-ultra-v1',
+        max_tokens: 500,
+        temperature: req.temperature,
+        kwargs: {
+          "topP":250,
+          "stop_sequences":[],
+          "countPenalty":{
+            "scale":0
+          },
+          "presencePenalty":{
+            "scale":0
+          },
+          "frequencyPenalty":{
+            "scale":0
+          }
+        }
+      } as AWSBedrockRequestBody),
+    responseHandler: OpenAIParseResponse,
+  },
+  amazon_titan_light: {
+    name: 'Titan Text Light',
+    distributor: 'Amazon',
+    apiEndpoint: `${appEnv.apiBaseURL}/api/awsbedrock/text`,
+    description:
+      'Right-sized for specific use cases, ideal for text generation tasks and fine-tuning.',
+    initialPrompt: DEFAULT_INITIAL_PROMPT,
+    maxTokensLimit: 4000,
+    isSecureModel: false,
+    supportFileUpload: false,
+    requirements: "AWS Account + Bedrock Enabled",
+    advanceMetadata: {
+      'Hosted on': 'Amazon Web Services (Bedrock)',
+      'Inference Hardware': 'GPU',
+      'Context window': '4k',
+    },
+    requestBody: (req: IRequestBody) =>
+      ({
+        prompt: req.messages.at(-1)?.content,
+        model: 'amazon.titan-text-lite-v1',
+        max_tokens: 500,
+        temperature: req.temperature,
+        kwargs: {
+          "stopSequences": [],
+          "topP": 1
+        }
+      } as AWSBedrockRequestBody),
+    responseHandler: OpenAIParseResponse,
+  }, 
+  amazon_titan_express: {
+    name: 'Titan Text Express',
+    distributor: 'Amazon',
+    apiEndpoint: `${appEnv.apiBaseURL}/api/awsbedrock/text`,
+    description:
+      'LLM offering a balance of price and performance.',
+    initialPrompt: DEFAULT_INITIAL_PROMPT,
+    maxTokensLimit: 8000,
+    isSecureModel: false,
+    supportFileUpload: false,
+    requirements: "AWS Account + Bedrock Enabled",
+    advanceMetadata: {
+      'Hosted on': 'Amazon Web Services (Bedrock)',
+      'Inference Hardware': 'GPU',
+      'Context window': '8k',
+    },
+    requestBody: (req: IRequestBody) =>
+      ({
+        prompt: req.messages.at(-1)?.content,
+        model: 'amazon.titan-text-express-v1',
+        max_tokens: 500,
+        temperature: req.temperature,
+        kwargs: {
+          "stopSequences": [],
+          "topP": 1
+        }
+      } as AWSBedrockRequestBody),
+    responseHandler: OpenAIParseResponse,
+  },
+  amazon_titan_embed: {
+    name: 'Titan Embeddings',
+    distributor: 'Amazon',
+    apiEndpoint: `${appEnv.apiBaseURL}/api/awsbedrock/embed`,
+    description:
+      'LLM that translates text into numerical representations.',
+    initialPrompt: DEFAULT_INITIAL_PROMPT,
+    maxTokensLimit: 8000,
+    isSecureModel: false,
+    supportFileUpload: false,
+    requirements: "AWS Account + Bedrock Enabled",
+    advanceMetadata: {
+      'Hosted on': 'Amazon Web Services (Bedrock)',
+      'Inference Hardware': 'GPU',
+      'Embeddings': '1536',
+    },
+    requestBody: (req: IRequestBody) =>
+      ({
+        messages: req.messages,
+        model: 'amazon.titan-embed-text-v1',
+        max_tokens: 500,
+        temperature: req.temperature,
+        kwargs: {}
+      } as AWSBedrockRequestBody),
+    responseHandler: OpenAIParseResponse,
+  },
+  amazon_titan_image_generation: {
+    name: 'Titan Image Generation',
+    distributor: 'Amazon',
+    apiEndpoint: `${appEnv.apiBaseURL}/api/awsbedrock/image`,
+    description:
+      'Generate realistic, studio-quality images using text prompts.',
+    initialPrompt: DEFAULT_INITIAL_PROMPT,
+    maxTokensLimit: 77,
+    isSecureModel: false,
+    supportFileUpload: false,
+    requirements: "AWS Account + Bedrock Enabled",
+    advanceMetadata: {
+      'Hosted on': 'Amazon Web Services (Bedrock)',
+      'Inference Hardware': 'GPU',
+    },
+    requestBody: (req: IRequestBody) =>
+      ({
+        prompt: req.messages.at(-1)?.content,
+        model: 'amazon.titan-image-generator-v1',
+        max_tokens: 77,
+        temperature: req.temperature,
+        kwargs: {
+          "numberOfImages": 1,
+          "quality": "standard",
+          "height": 1024,
+          "width": 1024,
+          "cfgScale": 8.0,
+          "seed": 0
+        }
+      } as AWSBedrockRequestBody),
+    responseHandler: OpenAIParseResponse,
+  },
+  anthropic_claude_v1: {
+    name: 'Claude 1.3',
+    distributor: 'Anthropic',
+    apiEndpoint: `${appEnv.apiBaseURL}/api/awsbedrock/text`,
+    description:
+      'Claude 1.3 is an earlier version of Anthropic\'s general-purpose LLM.',
+    initialPrompt: DEFAULT_INITIAL_PROMPT,
+    maxTokensLimit: 100000,
+    isSecureModel: false,
+    supportFileUpload: false,
+    requirements: "AWS Account + Bedrock Enabled",
+    advanceMetadata: {
+      'Hosted on': 'Amazon Web Services (Bedrock)',
+      'Inference Hardware': 'GPU',
+      'Context window': '100k',
+    },
+    requestBody: (req: IRequestBody) =>
+      ({
+        prompt: req.messages.at(-1)?.content,
+        model: 'anthropic.claude-v1',
+        max_tokens: 500,
+        temperature: req.temperature,
+        kwargs: {
+          "top_k": 250,
+          "top_p": 1,
+          "stop_sequences": [
+            "\n\nHuman:"
+          ],
+        }
+      } as AWSBedrockRequestBody),
+    responseHandler: OpenAIParseResponse,
+  }, 
+  anthropic_claude_v2: {
+    name: 'Claude 2.0',
+    distributor: 'Anthropic',
+    apiEndpoint: `${appEnv.apiBaseURL}/api/awsbedrock/text`,
+    description:
+      'Claude 2.0 is a leading LLM from Anthropic that enables a wide range of tasks from sophisticated dialogue and creative content generation to detailed instruction.',
+    initialPrompt: DEFAULT_INITIAL_PROMPT,
+    maxTokensLimit: 100000,
+    isSecureModel: false,
+    supportFileUpload: false,
+    requirements: "AWS Account + Bedrock Enabled",
+    advanceMetadata: {
+      'Hosted on': 'Amazon Web Services (Bedrock)',
+      'Inference Hardware': 'GPU',
+      'Context window': '100k',
+    },
+    requestBody: (req: IRequestBody) =>
+      ({
+        prompt: req.messages.at(-1)?.content,
+        model: 'anthropic.claude-v2',
+        max_tokens: 500,
+        temperature: req.temperature,
+        kwargs: {
+          "top_k": 250,
+          "top_p": 1,
+          "stop_sequences": [
+            "\n\nHuman:"
+          ],
+        }
+      } as AWSBedrockRequestBody),
+    responseHandler: OpenAIParseResponse,
+  },
+  anthropic_claude_v2_1: {
+    name: 'Claude 2.1',
+    distributor: 'Anthropic',
+    apiEndpoint: `${appEnv.apiBaseURL}/api/awsbedrock/text`,
+    description:
+      'Claude 2.1 is Anthropic\'s latest large language model (LLM) with an industry-leading 200K token context window, reduced hallucination rates, and improved accuracy over long documents.',
+    initialPrompt: DEFAULT_INITIAL_PROMPT,
+    maxTokensLimit: 200000,
+    isSecureModel: false,
+    supportFileUpload: false,
+    requirements: "AWS Account + Bedrock Enabled",
+    advanceMetadata: {
+      'Hosted on': 'Amazon Web Services (Bedrock)',
+      'Inference Hardware': 'GPU',
+      'Context window': '200k',
+    },
+    requestBody: (req: IRequestBody) =>
+      ({
+        prompt: req.messages.at(-1)?.content,
+        model: 'anthropic.claude-v2:1',
+        max_tokens: 500,
+        temperature: req.temperature,
+        kwargs: {
+          "top_k": 250,
+          "top_p": 1,
+          "stop_sequences": [
+            "\n\nHuman:"
+          ],
+        }
+      } as AWSBedrockRequestBody),
+    responseHandler: OpenAIParseResponse,
+  },
+  anthropic_claude_instant_v1: {
+    name: 'Claude Instant',
+    distributor: 'Anthropic',
+    apiEndpoint: `${appEnv.apiBaseURL}/api/awsbedrock/text`,
+    description:
+      'Claude Instant is Anthropic\'s faster, lower-priced yet very capable LLM.',
+    initialPrompt: DEFAULT_INITIAL_PROMPT,
+    maxTokensLimit: 100000,
+    isSecureModel: false,
+    supportFileUpload: false,
+    requirements: "AWS Account + Bedrock Enabled",
+    advanceMetadata: {
+      'Hosted on': 'Amazon Web Services (Bedrock)',
+      'Inference Hardware': 'GPU',
+      'Context window': '100k',
+    },
+    requestBody: (req: IRequestBody) =>
+      ({
+        prompt: req.messages.at(-1)?.content,
+        model: 'anthropic.claude-instant-v1',
+        max_tokens: 500,
+        temperature: req.temperature,
+        kwargs: {
+          "top_k": 250,
+          "top_p": 1,
+          "stop_sequences": [
+            "\n\nHuman:"
+          ],
+        }
+      } as AWSBedrockRequestBody),
+    responseHandler: OpenAIParseResponse,
+  }, 
+  cohere_command_v14: {
+    name: 'Command',
+    distributor: 'Cohere',
+    apiEndpoint: `${appEnv.apiBaseURL}/api/awsbedrock/text`,
+    description:
+      'Command is Cohere\'s generative large language model (LLM) (52B parameters).',
+    initialPrompt: DEFAULT_INITIAL_PROMPT,
+    maxTokensLimit: 4000,
+    isSecureModel: false,
+    supportFileUpload: false,
+    requirements: "AWS Account + Bedrock Enabled",
+    advanceMetadata: {
+      'Hosted on': 'Amazon Web Services (Bedrock)',
+      'Inference Hardware': 'GPU',
+      'Context window': '4k',
+    },
+    requestBody: (req: IRequestBody) =>
+      ({
+        prompt: req.messages.at(-1)?.content,
+        model: 'cohere.command-text-v14',
+        max_tokens: 500,
+        temperature: req.temperature,
+        kwargs: {}
+      } as AWSBedrockRequestBody),
+    responseHandler: OpenAIParseResponse,
+  },
+  cohere_command_light_v14: {
+    name: 'Command Light',
+    distributor: 'Cohere',
+    apiEndpoint: `${appEnv.apiBaseURL}/api/awsbedrock/text`,
+    description:
+      'Command Light is a smaller version of Command, Cohere\'s generative LLM (6B parameters).',
+    initialPrompt: DEFAULT_INITIAL_PROMPT,
+    maxTokensLimit: 4000,
+    isSecureModel: false,
+    supportFileUpload: false,
+    requirements: "AWS Account + Bedrock Enabled",
+    advanceMetadata: {
+      'Hosted on': 'Amazon Web Services (Bedrock)',
+      'Inference Hardware': 'GPU',
+      'Context window': '4k',
+    },
+    requestBody: (req: IRequestBody) =>
+      ({
+        prompt: req.messages.at(-1)?.content,
+        model: 'cohere.command-light-text-v14',
+        max_tokens: 500,
+        temperature: req.temperature,
+        kwargs: {}
+      } as AWSBedrockRequestBody),
+    responseHandler: OpenAIParseResponse,
+  },
+  cohere_embed_english_v3: {
+    name: 'Embed (English)',
+    distributor: 'Cohere',
+    apiEndpoint: `${appEnv.apiBaseURL}/api/awsbedrock/embed`,
+    description:
+      'Embed is Cohere\'s text representation, or embeddings, model. This version supports English only.',
+    initialPrompt: DEFAULT_INITIAL_PROMPT,
+    maxTokensLimit: 1024,
+    isSecureModel: false,
+    supportFileUpload: false,
+    requirements: "AWS Account + Bedrock Enabled",
+    advanceMetadata: {
+      'Hosted on': 'Amazon Web Services (Bedrock)',
+      'Inference Hardware': 'GPU',
+      'Context window': '4k',
+    },
+    requestBody: (req: IRequestBody) =>
+      ({
+        messages: req.messages,
+        model: 'cohere.embed-english-v3',
+        max_tokens: 500,
+        temperature: req.temperature,
+        kwargs: {}
+      } as AWSBedrockRequestBody),
+    responseHandler: OpenAIParseResponse,
+  },
+  cohere_embed_multilingual_v3: {
+    name: 'Embed (Multilingual)',
+    distributor: 'Cohere',
+    apiEndpoint: `${appEnv.apiBaseURL}/api/awsbedrock/embed`,
+    description:
+      'Embed is Cohere\'s text representation, or embeddings, model. This version supports multiple languages.',
+    initialPrompt: DEFAULT_INITIAL_PROMPT,
+    maxTokensLimit: 1024,
+    isSecureModel: false,
+    supportFileUpload: false,
+    requirements: "AWS Account + Bedrock Enabled",
+    advanceMetadata: {
+      'Hosted on': 'Amazon Web Services (Bedrock)',
+      'Inference Hardware': 'GPU',
+      'Context window': '4k',
+    },
+    requestBody: (req: IRequestBody) =>
+      ({
+        messages: req.messages,
+        model: 'cohere.embed-multilingual-v3',
+        max_tokens: 500,
+        temperature: req.temperature,
+        kwargs: {}
+      } as AWSBedrockRequestBody),
+    responseHandler: OpenAIParseResponse,
+  },
+  stability_stable_diffusion_xl_v0: {
+    name: 'Stable Diffusion XL 0.8',
+    distributor: 'Stability AI',
+    apiEndpoint: `${appEnv.apiBaseURL}/api/awsbedrock/image`,
+    description:
+      'Text-to-image model from Stability AI.',
+    initialPrompt: DEFAULT_INITIAL_PROMPT,
+    maxTokensLimit: 77,
+    isSecureModel: false,
+    supportFileUpload: false,
+    requirements: "AWS Account + Bedrock Enabled",
+    advanceMetadata: {
+      'Hosted on': 'Amazon Web Services (Bedrock)',
+      'Inference Hardware': 'GPU',
+    },
+    requestBody: (req: IRequestBody) =>
+      ({
+        prompt: req.messages.at(-1)?.content,
+        model: 'stability.stable-diffusion-xl-v0',
+        max_tokens: 77,
+        temperature: req.temperature,
+        kwargs: {
+          "cfg_scale":10,
+          "seed":0,
+          "steps":30
+        }
+      } as AWSBedrockRequestBody),
+    responseHandler: OpenAIParseResponse,
+  },
+  stability_stable_diffusion_xl_v1: {
+    name: 'Stable Diffusion XL 1.0',
+    distributor: 'Stability AI',
+    apiEndpoint: `${appEnv.apiBaseURL}/api/awsbedrock/image`,
+    description:
+      'The most advanced text-to-image model from Stability AI.',
+    initialPrompt: DEFAULT_INITIAL_PROMPT,
+    maxTokensLimit: 77,
+    isSecureModel: false,
+    supportFileUpload: false,
+    requirements: "AWS Account + Bedrock Enabled",
+    advanceMetadata: {
+      'Hosted on': 'Amazon Web Services (Bedrock)',
+      'Inference Hardware': 'GPU',
+    },
+    requestBody: (req: IRequestBody) =>
+    ({
+      prompt: req.messages.at(-1)?.content,
+      model: 'stability.stable-diffusion-xl-v1',
+      max_tokens: 77,
+      temperature: req.temperature,
+      kwargs: {
+        "cfg_scale":10,
+        "seed":0,
+        "steps":30
+      }
+    } as AWSBedrockRequestBody),
     responseHandler: OpenAIParseResponse,
   },
 };

--- a/front_end/src/constants.tsx
+++ b/front_end/src/constants.tsx
@@ -211,7 +211,7 @@ export const modelChoices: Models = {
       ({
         prompt: req.messages.at(-1)?.content,
         model: 'meta.llama2-13b-chat-v1',
-        max_tokens: 500, // TODO : add model config dialog to remove hardcoded values (i.e max_tokens, temperature, model_kwargs)
+        max_tokens: 4000, // TODO : add model config dialog to remove hardcoded values (i.e max_tokens, temperature, model_kwargs)
         temperature: req.temperature,
         instructions: DEFAULT_INITIAL_PROMPT[0].content,
         model_kwargs: {
@@ -240,7 +240,7 @@ export const modelChoices: Models = {
       ({
         prompt: req.messages.at(-1)?.content,
         model: 'meta.llama2-70b-chat-v1',
-        max_tokens: 500,
+        max_tokens: 4000,
         temperature: req.temperature,
         instruction: DEFAULT_INITIAL_PROMPT[0].content,
         model_kwargs: {
@@ -269,7 +269,7 @@ export const modelChoices: Models = {
       ({
         prompt: req.messages.at(-1)?.content,
         model: 'ai21.j2-mid-v1',
-        max_tokens: 500,
+        max_tokens: 8192,
         temperature: req.temperature,
         model_kwargs: {
           "topP": 1,
@@ -306,7 +306,7 @@ export const modelChoices: Models = {
       ({
         prompt: req.messages.at(-1)?.content,
         model: 'ai21.j2-ultra-v1',
-        max_tokens: 500,
+        max_tokens: 8192,
         temperature: req.temperature,
         model_kwargs: {
           "topP": 1,
@@ -343,7 +343,7 @@ export const modelChoices: Models = {
       ({
         prompt: req.messages.at(-1)?.content,
         model: 'amazon.titan-text-lite-v1',
-        max_tokens: 500,
+        max_tokens: 4000,
         temperature: req.temperature,
         model_kwargs: {
           "stopSequences": [],
@@ -372,7 +372,7 @@ export const modelChoices: Models = {
       ({
         prompt: req.messages.at(-1)?.content,
         model: 'amazon.titan-text-express-v1',
-        max_tokens: 500,
+        max_tokens: 8000,
         temperature: req.temperature,
         model_kwargs: {
           "stopSequences": [],
@@ -401,7 +401,7 @@ export const modelChoices: Models = {
       ({
         embedding_texts: [req.messages.at(-1)?.content],
         model: 'amazon.titan-embed-text-v1',
-        max_tokens: 500,
+        max_tokens: 8000,
       } as AWSBedrockRequestBody),
     responseHandler: AWSBedrockTitanEmbedParseResponse,
   },
@@ -425,7 +425,7 @@ export const modelChoices: Models = {
       ({
         prompt: req.messages.at(-1)?.content,
         model: 'anthropic.claude-v1',
-        max_tokens: 500,
+        max_tokens: 100000,
         temperature: req.temperature,
         model_kwargs: {
           "top_k": 250,
@@ -457,7 +457,7 @@ export const modelChoices: Models = {
       ({
         prompt: req.messages.at(-1)?.content,
         model: 'anthropic.claude-v2',
-        max_tokens: 500,
+        max_tokens: 100000,
         temperature: req.temperature,
         model_kwargs: {
           "top_k": 250,
@@ -489,7 +489,7 @@ export const modelChoices: Models = {
       ({
         prompt: req.messages.at(-1)?.content,
         model: 'anthropic.claude-v2:1',
-        max_tokens: 500,
+        max_tokens: 200000,
         temperature: req.temperature,
         model_kwargs: {
           "top_k": 250,
@@ -521,7 +521,7 @@ export const modelChoices: Models = {
       ({
         prompt: req.messages.at(-1)?.content,
         model: 'anthropic.claude-instant-v1',
-        max_tokens: 500,
+        max_tokens: 100000,
         temperature: req.temperature,
         model_kwargs: {
           "top_k": 250,
@@ -553,7 +553,7 @@ export const modelChoices: Models = {
       ({
         prompt: req.messages.at(-1)?.content,
         model: 'cohere.command-text-v14',
-        max_tokens: 50,
+        max_tokens: 4000,
         temperature: req.temperature,
         model_kwargs: {
           "p": 0.75,
@@ -584,7 +584,7 @@ export const modelChoices: Models = {
       ({
         prompt: req.messages.at(-1)?.content,
         model: 'cohere.command-light-text-v14',
-        max_tokens: 50,
+        max_tokens: 4000,
         temperature: req.temperature,
         model_kwargs: {
           "p": 0.75,
@@ -615,7 +615,7 @@ export const modelChoices: Models = {
       ({
         embedding_texts: [req.messages.at(-1)?.content],
         model: 'cohere.embed-english-v3',
-        max_tokens: 50,
+        max_tokens: 1024,
       } as AWSBedrockRequestBody),
       responseHandler: AWSBedrockCohereEmbedParseResponse,
     },
@@ -639,7 +639,7 @@ export const modelChoices: Models = {
       ({
         embedding_texts: [req.messages.at(-1)?.content],
         model: 'cohere.embed-multilingual-v3',
-        max_tokens: 50,
+        max_tokens: 1024,
       } as AWSBedrockRequestBody),
       responseHandler: AWSBedrockCohereEmbedParseResponse,
   },

--- a/llm_gateway/README.md
+++ b/llm_gateway/README.md
@@ -1,0 +1,69 @@
+# llm-gateway
+
+## Cohere
+
+### Setup
+
+*This setup requires a Cohere account. If you do not have a Cohere account, you can create one [here](https://cohere.ai/).*
+
+### Available Models
+
+
+
+## OpenAI
+
+### Setup
+
+*This setup requires an OpenAI account. If you do not have an OpenAI account, you can create one [here](https://beta.openai.com/).*
+
+### Available Models
+
+
+
+
+
+## AWS Bedrock
+
+### Setup
+
+*This setup requires an Amazon Web Services (AWS) account. If you do not have an AWS account, you can create one [here](https://aws.amazon.com/).*
+
+*Steps 1 and 2 are to configure the AWS CLI for boto3. If you already have the AWS CLI configured, you can skip to step 3.*
+
+1. Install the AWS CLI. OS-specific installation instructions can be found [here](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html).
+2. Setup the AWS CLI. Setup instructions can be found [here](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-config).
+3. Enable Amazon Bedrock on your AWS account using the AWS Console.
+4. Within Amazon Bedrock in the AWS Console, select `Model access` > `Manage Model Access`, and enable the LLM models you want to use. </br> **Pricing information for models offered on Amazon Bedrock can be found** [here](https://aws.amazon.com/bedrock/pricing/).
+5. Set the `AWS_REGION` environment variable to the region in which Amazon Bedrock is enabled on your AWS account </br> **(i.e AWS_REGION=us-east-1)**.
+
+### Available Models
+
+**AI21 Labs**
+- Jurrasic-2 Ultra
+- Jurassic-2 Mid
+
+**Amazon**
+- Titan Text Lite
+- Titan Text Express
+- Titan Text Embeddings
+- Titan Image Generator
+
+**Anthropic**
+- Claude 2.1
+- Claude 2.0
+- Claude 1.3
+- Claude Instant
+
+**Cohere**
+- Command
+- Command Light
+- Embed - English
+- Embed - Multilingual
+
+**Meta**
+- Llama-2-13b-chat
+- Llama-2-70b-chat
+
+**Stable Diffusion**
+- Stable Diffusion XL 1.0
+- Stable Diffusion XL 0.8

--- a/llm_gateway/README.md
+++ b/llm_gateway/README.md
@@ -6,9 +6,13 @@
 
 *This setup requires a Cohere account. If you do not have a Cohere account, you can create one [here](https://cohere.ai/).*
 
+1. Login to your Cohere account and select `API keys` to view your API keys.
+2. If you do not have an existing API key, select `Create Trial key` to create one.
+3. Within llm-gateway, set the `COHERE_API_KEY` environment variable to your API key.
+
 ### Available Models
 
-
+- Command Light
 
 ## OpenAI
 
@@ -16,11 +20,16 @@
 
 *This setup requires an OpenAI account. If you do not have an OpenAI account, you can create one [here](https://beta.openai.com/).*
 
+1. Login to your OpenAI account and navigate to the API page.
+2. Select `API keys` to view your API keys.
+2. If you do not have an existing API key, select `Create new secret key` to create one.
+3. Within llm-gateway, set the `OPENAI_API_KEY` environment variable to your API key.
+
 ### Available Models
 
-
-
-
+- GPT 3.5 Turbo
+- GPT 3.5 Turbo 16k
+- GPT 4
 
 ## AWS Bedrock
 
@@ -28,13 +37,10 @@
 
 *This setup requires an Amazon Web Services (AWS) account. If you do not have an AWS account, you can create one [here](https://aws.amazon.com/).*
 
-*Steps 1 and 2 are to configure the AWS CLI for boto3. If you already have the AWS CLI configured, you can skip to step 3.*
-
-1. Install the AWS CLI. OS-specific installation instructions can be found [here](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html).
-2. Setup the AWS CLI. Setup instructions can be found [here](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-config).
-3. Enable Amazon Bedrock on your AWS account using the AWS Console.
-4. Within Amazon Bedrock in the AWS Console, select `Model access` > `Manage Model Access`, and enable the LLM models you want to use. </br> **Pricing information for models offered on Amazon Bedrock can be found** [here](https://aws.amazon.com/bedrock/pricing/).
-5. Set the `AWS_REGION` environment variable to the region in which Amazon Bedrock is enabled on your AWS account </br> **(i.e AWS_REGION=us-east-1)**.
+1. Enable Amazon Bedrock on your AWS account using the AWS Console.
+2. Within Amazon Bedrock in the AWS Console, select `Model access` > `Manage Model Access`, and enable the LLM models you want to use. </br> **Pricing information for models offered on Amazon Bedrock can be found** [here](https://aws.amazon.com/bedrock/pricing/).
+3. Within llm-gateway, set the `AWS_REGION` environment variable to the region in which Amazon Bedrock is enabled on your AWS account.
+4. Within llm-gateway, set the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables to the access key ID and secret access key of the AWS account you enabled Amazon Bedrock on.
 
 ### Available Models
 
@@ -46,7 +52,6 @@
 - Titan Text Lite
 - Titan Text Express
 - Titan Text Embeddings
-- Titan Image Generator
 
 **Anthropic**
 - Claude 2.1
@@ -63,7 +68,3 @@
 **Meta**
 - Llama-2-13b-chat
 - Llama-2-70b-chat
-
-**Stable Diffusion**
-- Stable Diffusion XL 1.0
-- Stable Diffusion XL 0.8

--- a/llm_gateway/app.py
+++ b/llm_gateway/app.py
@@ -19,7 +19,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from llm_gateway.constants import get_settings
-from llm_gateway.routers import cohere_api, openai_api
+from llm_gateway.routers import cohere_api, openai_api, awsbedrock_api
 
 settings = get_settings()
 
@@ -33,6 +33,7 @@ api.title = settings.APP_TITLE
 api.description = settings.APP_DESCRIPTION
 api.include_router(openai_api.router, prefix="/openai")
 api.include_router(cohere_api.router, prefix="/cohere")
+api.include_router(awsbedrock_api.router, prefix="/awsbedrock")
 
 app.mount(settings.API_PREFIX, api, name="api")
 

--- a/llm_gateway/app.py
+++ b/llm_gateway/app.py
@@ -19,7 +19,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from llm_gateway.constants import get_settings
-from llm_gateway.routers import cohere_api, openai_api, awsbedrock_api
+from llm_gateway.routers import awsbedrock_api, cohere_api, openai_api
 
 settings = get_settings()
 
@@ -28,7 +28,7 @@ app.title = settings.APP_TITLE
 app.description = settings.APP_DESCRIPTION
 
 
-api = FastAPI(openapi_prefix="/api")
+api = FastAPI(root_path="/api")
 api.title = settings.APP_TITLE
 api.description = settings.APP_DESCRIPTION
 api.include_router(openai_api.router, prefix="/openai")

--- a/llm_gateway/constants.py
+++ b/llm_gateway/constants.py
@@ -47,6 +47,11 @@ class Settings(BaseSettings):
     OPENAI_API_KEY: Optional[str]
     COHERE_API_KEY: Optional[str]
 
+    # AWS Client Keys
+    AWS_REGION: Optional[str]
+    AWS_PROFILE: Optional[str]
+    AWS_ROLE_ARN: Optional[str]
+
     # Postgres Database
     DATABASE_URL: str
 

--- a/llm_gateway/constants.py
+++ b/llm_gateway/constants.py
@@ -47,8 +47,10 @@ class Settings(BaseSettings):
     OPENAI_API_KEY: Optional[str]
     COHERE_API_KEY: Optional[str]
 
-    # AWS Client / Boto3 Config
+    # AWS Client Keys
     AWS_REGION: Optional[str]
+    AWS_PUBLIC_ACCESS_KEY: Optional[str]
+    AWS_PRIVATE_ACCESS_KEY: Optional[str]
 
     # Postgres Database
     DATABASE_URL: str

--- a/llm_gateway/constants.py
+++ b/llm_gateway/constants.py
@@ -47,10 +47,8 @@ class Settings(BaseSettings):
     OPENAI_API_KEY: Optional[str]
     COHERE_API_KEY: Optional[str]
 
-    # AWS Client Keys
+    # AWS Client / Boto3 Config
     AWS_REGION: Optional[str]
-    AWS_PROFILE: Optional[str]
-    AWS_ROLE_ARN: Optional[str]
 
     # Postgres Database
     DATABASE_URL: str

--- a/llm_gateway/db/models.py
+++ b/llm_gateway/db/models.py
@@ -29,9 +29,9 @@ class OpenAIRequests(Base):
     openai_response = Column(JSON, nullable=True)
     openai_model = Column(String, nullable=True)
     temperature = Column(Float, nullable=True)
-    extras = Column(JSON, nullable=True)
     created_at = Column(DateTime, nullable=False)
     openai_endpoint = Column(String, nullable=False)
+    extras = Column(JSON, nullable=True)
 
 
 class CohereRequests(Base):
@@ -44,4 +44,16 @@ class CohereRequests(Base):
     temperature = Column(Float, nullable=True)
     created_at = Column(DateTime, nullable=False)
     cohere_endpoint = Column(String, nullable=False)
+    extras = Column(JSON, nullable=True)
+
+class AWSBedrockRequests(Base):
+    __tablename__ = "awsbedrock_requests"
+    id = Column(Integer, nullable=False, primary_key=True, autoincrement=True)
+    user_input = Column(String, nullable=True)
+    user_email = Column(String, nullable=True)
+    awsbedrock_response = Column(JSON, nullable=True)
+    awsbedrock_model = Column(String, nullable=True)
+    temperature = Column(Float, nullable=True)
+    created_at = Column(DateTime, nullable=False)
+    awsbedrock_endpoint = Column(String, nullable=False)
     extras = Column(JSON, nullable=True)

--- a/llm_gateway/exceptions.py
+++ b/llm_gateway/exceptions.py
@@ -39,6 +39,7 @@ OPENAI_EXCEPTIONS = (
     AuthenticationError,
 )
 COHERE_EXCEPTIONS = (CohereError, CohereAPIError, CohereConnectionError)
+AWSBEDROCK_EXCEPTIONS = ()
 
 logger = get_logger(__name__)
 
@@ -59,7 +60,7 @@ class OpenAIRouteExceptionHandler(APIRoute):
 
             :param request: The request object
             :type request: Request
-            :return: Internal server error response with error message
+            :return: Response or Internal server error response with error message
             :rtype: JSONResponse
             """
             try:
@@ -92,12 +93,45 @@ class CohereRouteExceptionHandler(APIRoute):
 
             :param request: The request object
             :type request: Request
-            :return: Internal server error response with error message
+            :return: Response or Internal server error response with error message
             :rtype: JSONResponse
             """
             try:
                 response = await original_route_handler(request)
             except COHERE_EXCEPTIONS as e:
+                # print exception traceback to console
+                logger.exception(type(e), e, e.__traceback__)
+                raise HTTPException(
+                    status_code=500,
+                    detail=str(e),
+                )
+            return response
+
+        return exception_handler
+
+
+class AWSBedrockRouteExceptionHandler(APIRoute):
+    """
+    This is a route class override for the AWS Bedrock router. It is used to
+    catch common exceptions that are raised by the AWS Bedrock API and return an
+    internal server error response with its associated error message.
+    """
+
+    def get_route_handler(self):
+        original_route_handler = super().get_route_handler()
+
+        async def exception_handler(request: Request) -> JSONResponse:
+            """
+            Catch AWS Bedrock exceptions and return an internal server error response.
+
+            :param request: The request object
+            :type request: Request
+            :return: Response or Internal server error response with error message
+            :rtype: JSONResponse
+            """
+            try:
+                response = await original_route_handler(request)
+            except AWSBEDROCK_EXCEPTIONS as e:
                 # print exception traceback to console
                 logger.exception(type(e), e, e.__traceback__)
                 raise HTTPException(

--- a/llm_gateway/exceptions.py
+++ b/llm_gateway/exceptions.py
@@ -15,6 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from botocore.exceptions import (
+    BotoCoreError,
+    ClientError,
+    ConnectionError,
+    InvalidRegionError,
+    NoCredentialsError,
+    NoRegionError,
+)
 from cohere.error import CohereAPIError, CohereConnectionError, CohereError
 from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse
@@ -39,7 +47,14 @@ OPENAI_EXCEPTIONS = (
     AuthenticationError,
 )
 COHERE_EXCEPTIONS = (CohereError, CohereAPIError, CohereConnectionError)
-AWSBEDROCK_EXCEPTIONS = ()
+AWSBEDROCK_EXCEPTIONS = (
+    BotoCoreError,
+    ClientError,
+    ConnectionError,
+    NoCredentialsError,
+    NoRegionError,
+    InvalidRegionError,
+)
 
 logger = get_logger(__name__)
 

--- a/llm_gateway/models.py
+++ b/llm_gateway/models.py
@@ -19,6 +19,8 @@ from typing import List
 
 from pydantic import BaseModel
 
+# Cohere models
+
 
 class GenerateInput(BaseModel):
     temperature: float
@@ -34,6 +36,9 @@ class SummarizeInput(BaseModel):
     additional_command: str = ""
     model: str = "command-light"
     model_kwargs: dict = {}
+
+
+# OpenAI models
 
 
 class CompletionInput(BaseModel):
@@ -63,3 +68,92 @@ class EditInput(BaseModel):
 class EmbeddingInput(BaseModel):
     embedding_texts: List[str]
     model: str = "text-embedding-ada-002"
+
+
+# AWS Bedrock models
+
+
+class Jurrasic2UltraCompletionInput(BaseModel):
+    model: str = "ai21.j2-ultra-v1"
+    max_tokens: int = 8192
+    prompt: str
+    temperature: float = 0
+    model_kwargs: dict = {}
+
+
+class Jurrasic2MidCompletionInput(BaseModel):
+    model: str = "ai21.j2-mid-v1"
+    max_tokens: int = 8192
+    prompt: str
+    temperature: float = 0
+    model_kwargs: dict = {}
+
+
+class Claude21CompletionInput(BaseModel):
+    model: str = "anthropic.claude-v2:1"
+    max_tokens: int = 200000
+    prompt: str
+    temperature: float = 0
+    model_kwargs: dict = {}
+
+
+class Claude20CompletionInput(BaseModel):
+    model: str = "anthropic.claude-v2"
+    max_tokens: int = 100000
+    prompt: str
+    temperature: float = 0
+    model_kwargs: dict = {}
+
+
+class Claude13CompletionInput(BaseModel):
+    model: str = "anthropic.claude-v1"
+    max_tokens: int = 100000
+    prompt: str
+    temperature: float = 0
+    model_kwargs: dict = {}
+
+
+class ClaudeInstantCompletionInput(BaseModel):
+    model: str = "anthropic.claude-instant-v1"
+    max_tokens: int = 100000
+    prompt: str
+    temperature: float = 0
+    model_kwargs: dict = {}
+
+
+class Llama213bCompletionInput(BaseModel):
+    model: str = "meta.llama2-13b-chat-v1"
+    max_tokens: int = 4000
+    prompt: str
+    temperature: float = 0
+    model_kwargs: dict = {}
+
+
+class Llama270bCompletionInput(BaseModel):
+    model: str = "meta.llama2-70b-chat-v1"
+    max_tokens: int = 4000
+    prompt: str
+    temperature: float = 0
+    model_kwargs: dict = {}
+
+
+class TitanExpressCompletionInput(BaseModel):
+    model: str = "amazon.titan-text-express-v1"
+    max_tokens: int = 8000
+    prompt: str
+    temperature: float = 0
+    model_kwargs: dict = {}
+
+
+class TitanLiteCompletionInput(BaseModel):
+    model: str = "amazon.titan-text-lite-v1"
+    max_tokens: int = 8000
+    prompt: str
+    temperature: float = 0
+    model_kwargs: dict = {}
+
+
+class TitanEmbeddingInput(BaseModel):
+    model: str = "amazon.titan-embed-text-v1"
+    max_tokens: int = 8000
+    embedding_texts: List[str]

--- a/llm_gateway/models.py
+++ b/llm_gateway/models.py
@@ -25,7 +25,7 @@ class GenerateInput(BaseModel):
     prompt: str
     max_tokens: int = 50
     model: str = "command-light"
-    model_kwargs: dict = {}
+    kwargs: dict = {}
 
 
 class SummarizeInput(BaseModel):
@@ -33,7 +33,7 @@ class SummarizeInput(BaseModel):
     prompt: str
     additional_command: str = ""
     model: str = "command-light"
-    model_kwargs: dict = {}
+    kwargs: dict = {}
 
 
 class CompletionInput(BaseModel):
@@ -41,7 +41,7 @@ class CompletionInput(BaseModel):
     prompt: str
     max_tokens: int = 50
     temperature: float = 0
-    model_kwargs: dict = {}
+    kwargs: dict = {}
 
 
 class ChatCompletionInput(BaseModel):
@@ -51,7 +51,7 @@ class ChatCompletionInput(BaseModel):
     ]
     temperature: float = 0
     max_tokens: int = 2000
-    model_kwargs: dict = {}
+    kwargs: dict = {}
 
 
 class EditInput(BaseModel):
@@ -65,17 +65,33 @@ class EmbeddingInput(BaseModel):
     model: str = "text-embedding-ada-002"
 
 
-class AWSBedrockInput(BaseModel):
+class AWSBedrockChatInput(BaseModel):
     model: str
     max_tokens: int
-    prompt: str
+    messages: List[str] = []
     temperature: float = 0
-    model_kwargs: dict = {}
+    kwargs: dict = {}
 
 
-class AmazonTitanCompletionInput(AWSBedrockInput):
-    model: str = ""
+class AWSBedrockTextInput(BaseModel):
+    model: str
     max_tokens: int
-    prompt: str
+    prompt: str = ""
     temperature: float = 0
-    model_kwargs: dict = {}
+    kwargs: dict = {}
+
+
+class AWSBedrockEmbedInput(BaseModel):
+    model: str
+    max_tokens: int
+    embedding_texts: List[str] = []
+    temperature: float = 0
+    kwargs: dict = {}
+
+
+class AWSBedrockImageInput(BaseModel):
+    model: str
+    max_tokens: int
+    prompt: str = ""
+    temperature: float = 0
+    kwargs: dict = {}

--- a/llm_gateway/models.py
+++ b/llm_gateway/models.py
@@ -65,7 +65,7 @@ class EmbeddingInput(BaseModel):
     model: str = "text-embedding-ada-002"
 
 
-class AWSBedrockCompletionInput(BaseModel):
+class AWSBedrockInput(BaseModel):
     model: str
     max_tokens: int
     prompt: str
@@ -73,7 +73,9 @@ class AWSBedrockCompletionInput(BaseModel):
     model_kwargs: dict = {}
 
 
-class AWSBedrockEmbeddingInput(BaseModel):
-    model: str
+class AmazonTitanCompletionInput(AWSBedrockInput):
+    model: str = ""
     max_tokens: int
-    embedding_texts: List[str]
+    prompt: str
+    temperature: float = 0
+    model_kwargs: dict = {}

--- a/llm_gateway/models.py
+++ b/llm_gateway/models.py
@@ -19,8 +19,6 @@ from typing import List
 
 from pydantic import BaseModel
 
-# Cohere models
-
 
 class GenerateInput(BaseModel):
     temperature: float
@@ -36,9 +34,6 @@ class SummarizeInput(BaseModel):
     additional_command: str = ""
     model: str = "command-light"
     model_kwargs: dict = {}
-
-
-# OpenAI models
 
 
 class CompletionInput(BaseModel):
@@ -70,90 +65,15 @@ class EmbeddingInput(BaseModel):
     model: str = "text-embedding-ada-002"
 
 
-# AWS Bedrock models
-
-
-class Jurrasic2UltraCompletionInput(BaseModel):
-    model: str = "ai21.j2-ultra-v1"
-    max_tokens: int = 8192
+class AWSBedrockCompletionInput(BaseModel):
+    model: str
+    max_tokens: int
     prompt: str
     temperature: float = 0
     model_kwargs: dict = {}
 
 
-class Jurrasic2MidCompletionInput(BaseModel):
-    model: str = "ai21.j2-mid-v1"
-    max_tokens: int = 8192
-    prompt: str
-    temperature: float = 0
-    model_kwargs: dict = {}
-
-
-class Claude21CompletionInput(BaseModel):
-    model: str = "anthropic.claude-v2:1"
-    max_tokens: int = 200000
-    prompt: str
-    temperature: float = 0
-    model_kwargs: dict = {}
-
-
-class Claude20CompletionInput(BaseModel):
-    model: str = "anthropic.claude-v2"
-    max_tokens: int = 100000
-    prompt: str
-    temperature: float = 0
-    model_kwargs: dict = {}
-
-
-class Claude13CompletionInput(BaseModel):
-    model: str = "anthropic.claude-v1"
-    max_tokens: int = 100000
-    prompt: str
-    temperature: float = 0
-    model_kwargs: dict = {}
-
-
-class ClaudeInstantCompletionInput(BaseModel):
-    model: str = "anthropic.claude-instant-v1"
-    max_tokens: int = 100000
-    prompt: str
-    temperature: float = 0
-    model_kwargs: dict = {}
-
-
-class Llama213bCompletionInput(BaseModel):
-    model: str = "meta.llama2-13b-chat-v1"
-    max_tokens: int = 4000
-    prompt: str
-    temperature: float = 0
-    model_kwargs: dict = {}
-
-
-class Llama270bCompletionInput(BaseModel):
-    model: str = "meta.llama2-70b-chat-v1"
-    max_tokens: int = 4000
-    prompt: str
-    temperature: float = 0
-    model_kwargs: dict = {}
-
-
-class TitanExpressCompletionInput(BaseModel):
-    model: str = "amazon.titan-text-express-v1"
-    max_tokens: int = 8000
-    prompt: str
-    temperature: float = 0
-    model_kwargs: dict = {}
-
-
-class TitanLiteCompletionInput(BaseModel):
-    model: str = "amazon.titan-text-lite-v1"
-    max_tokens: int = 8000
-    prompt: str
-    temperature: float = 0
-    model_kwargs: dict = {}
-
-
-class TitanEmbeddingInput(BaseModel):
-    model: str = "amazon.titan-embed-text-v1"
-    max_tokens: int = 8000
+class AWSBedrockEmbeddingInput(BaseModel):
+    model: str
+    max_tokens: int
     embedding_texts: List[str]

--- a/llm_gateway/models.py
+++ b/llm_gateway/models.py
@@ -25,7 +25,7 @@ class GenerateInput(BaseModel):
     prompt: str
     max_tokens: int = 50
     model: str = "command-light"
-    kwargs: dict = {}
+    model_kwargs: dict = {}
 
 
 class SummarizeInput(BaseModel):
@@ -33,7 +33,7 @@ class SummarizeInput(BaseModel):
     prompt: str
     additional_command: str = ""
     model: str = "command-light"
-    kwargs: dict = {}
+    model_kwargs: dict = {}
 
 
 class CompletionInput(BaseModel):
@@ -41,7 +41,7 @@ class CompletionInput(BaseModel):
     prompt: str
     max_tokens: int = 50
     temperature: float = 0
-    kwargs: dict = {}
+    model_kwargs: dict = {}
 
 
 class ChatCompletionInput(BaseModel):
@@ -51,7 +51,7 @@ class ChatCompletionInput(BaseModel):
     ]
     temperature: float = 0
     max_tokens: int = 2000
-    kwargs: dict = {}
+    model_kwargs: dict = {}
 
 
 class EditInput(BaseModel):
@@ -65,33 +65,15 @@ class EmbeddingInput(BaseModel):
     model: str = "text-embedding-ada-002"
 
 
-class AWSBedrockChatInput(BaseModel):
-    model: str
-    max_tokens: int
-    messages: List[str] = []
-    temperature: float = 0
-    kwargs: dict = {}
-
-
 class AWSBedrockTextInput(BaseModel):
     model: str
     max_tokens: int
     prompt: str = ""
     temperature: float = 0
-    kwargs: dict = {}
+    model_kwargs: dict = {}
 
 
 class AWSBedrockEmbedInput(BaseModel):
     model: str
     max_tokens: int
     embedding_texts: List[str] = []
-    temperature: float = 0
-    kwargs: dict = {}
-
-
-class AWSBedrockImageInput(BaseModel):
-    model: str
-    max_tokens: int
-    prompt: str = ""
-    temperature: float = 0
-    kwargs: dict = {}

--- a/llm_gateway/providers/awsbedrock.py
+++ b/llm_gateway/providers/awsbedrock.py
@@ -22,17 +22,17 @@ import boto3
 
 from llm_gateway.constants import get_settings
 from llm_gateway.db.models import AWSBedrockRequests
+from llm_gateway.exceptions import AWSBEDROCK_EXCEPTIONS
 from llm_gateway.db.utils import write_record_to_db
 from llm_gateway.pii_scrubber import scrub_all
 from llm_gateway.utils import StreamProcessor, max_retries
 
 settings = get_settings()
 
-AWSBEDROCK_EXCEPTIONS = ()
 
 SUPPORTED_AWSBEDROCK_ENDPOINTS = {
-    "Completion": ("Create"),
-    "Embedding": ("Create"),
+    "Completion": ("create"),
+    "Embedding": ("create"),
 }
 
 

--- a/llm_gateway/providers/awsbedrock.py
+++ b/llm_gateway/providers/awsbedrock.py
@@ -1,0 +1,92 @@
+# llm-gateway - A proxy service in front of llm models to encourage the
+# responsible use of AI.
+#
+# Copyright 2023 Wealthsimple Technologies
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import boto3
+
+from llm_gateway.constants import get_settings
+
+settings = get_settings()
+
+SUPPORTED_AWSBEDROCK_ENDPOINTS = {
+    "": ("", ""),
+    "": "",
+}
+
+
+class AWSBedrockWrapper:
+    """ """
+
+    def __init__(self) -> None:
+        self._bedrock_runtime = self._setup_client()
+
+    def _setup_client(self) -> boto3.client:
+        """
+        Setup the AWS Bedrock client with the appropriate credentials
+
+
+        :return: The AWS Bedrock client
+        """
+        session_kwargs = {
+            "region_name": settings.AWS_REGION,
+            "profile_name": settings.AWS_PROFILE,
+        }
+
+        session = boto3.Session(**session_kwargs)
+
+        res = session.client("sts").assume_role(
+            RoleArn=settings.AWS_ROLE_ARN,
+            RoleSessionName=settings.APP_NAME,
+        )
+
+        client_kwargs = {
+            **session_kwargs,
+            "aws_access_key_id": res["Credentials"]["AccessKeyId"],
+            "aws_secret_access_key": res["Credentials"]["SecretAccessKey"],
+            "aws_session_token": res["Credentials"]["SessionToken"],
+        }
+
+        bedrock_runtime = session.client(
+            service_name="bedrock-runtime", config=0, **client_kwargs
+        )
+
+        return bedrock_runtime
+
+    def _validate_awsbedrock_endpoint(self, module: str, endpoint: str) -> None:
+        """
+        Check if module and endpoint are supported in AWS Bedrock, else raise an error
+
+        :param module: The name of an OpenAI module (i.e. "Completion")
+        :type module: str
+        :param endpoint: The name of an OpenAI endpoint (i.e. "create")
+        :type endpoint: str
+        :raises NotImplementedError: Raised if OpenAI module or endpoint is not supported
+        """
+        if module not in SUPPORTED_AWSBEDROCK_ENDPOINTS:
+            raise NotImplementedError(
+                f"`awsbedrock_endpoint` must be one of `{SUPPORTED_AWSBEDROCK_ENDPOINTS.keys()}`"
+            )
+
+        if endpoint not in SUPPORTED_AWSBEDROCK_ENDPOINTS[module]:
+            raise NotImplementedError(
+                f"`{endpoint}` not supported action for `{module}`"
+            )
+
+    def send_awsbedrock_request(self):
+        """ """
+        pass

--- a/llm_gateway/routers/api.py
+++ b/llm_gateway/routers/api.py
@@ -21,12 +21,14 @@ from fastapi.middleware.cors import CORSMiddleware
 from llm_gateway.constants import AppEnv, get_settings
 from llm_gateway.routers.cohere_api import router as CohereRouter
 from llm_gateway.routers.openai_api import router as OpenAIRouter
+from llm_gateway.routers.awsbedrock_api import router as AWSBedrockRouter
 
 settings = get_settings()
 
 api_app = FastAPI()
 api_app.include_router(OpenAIRouter, prefix="/openai")
 api_app.include_router(CohereRouter, prefix="/cohere")
+api_app.include_router(AWSBedrockRouter, prefix="/awsbedrock")
 
 # allow CORS for local development with frontend
 if settings.APP_ENV in (AppEnv.DEVELOPMENT, AppEnv.STAGING):

--- a/llm_gateway/routers/awsbedrock_api.py
+++ b/llm_gateway/routers/awsbedrock_api.py
@@ -1,0 +1,108 @@
+# llm-gateway - A proxy service in front of llm models to encourage the
+# responsible use of AI.
+#
+# Copyright 2023 Wealthsimple Technologies
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from fastapi import APIRouter, BackgroundTasks
+from fastapi.responses import StreamingResponse
+from starlette.responses import JSONResponse
+
+from llm_gateway.exceptions import AWSBedrockRouteExceptionHandler
+from llm_gateway.models import (
+    AWSBedrockCompletionInput,
+    AWSBedrockEmbeddingInput,
+)
+from llm_gateway.providers.awsbedrock import AWSBedrockWrapper
+from llm_gateway.utils import reraise_500
+
+router = APIRouter(route_class=AWSBedrockRouteExceptionHandler)
+
+@router.post("/completion")
+@reraise_500
+def get_completion(
+    user_input: AWSBedrockCompletionInput, background_tasks: BackgroundTasks
+) -> JSONResponse:
+    """
+    Use the AWS Bedrock completion API to generate a response to a prompt
+
+    :param user_input: Inputs to the AWS Bedrock completion API, including model and prompt
+    :type user_input: AWSBedrockCompletionInput
+    :return: Dictionary with LLM response and metadata
+    :rtype: JSONResponse
+    """
+    wrapper = AWSBedrockWrapper()
+    resp, logs = wrapper.send_awsbedrock_request(
+        "Completion",
+        "create",
+        model=user_input.model,
+        max_tokens=user_input.max_tokens,
+        prompt=user_input.prompt,
+        temperature=user_input.temperature,
+        **user_input.model_kwargs,
+    )
+
+    background_tasks.add_task(wrapper.write_logs_to_db, db_logs=logs)
+    return JSONResponse(resp)
+
+@router.post("/completion/streaming")
+@reraise_500
+def get_completion_stream(
+    user_input: AWSBedrockCompletionInput, background_tasks: BackgroundTasks
+) -> StreamingResponse:
+    """
+    Use the AWS Bedrock completion API to generate a stream response to a prompt
+
+    :param user_input: Inputs to the AWS Bedrock completion API, including model and prompt
+    :type user_input: AWSBedrockCompletionInput
+    :return: LLM response and metadata
+    :rtype: StreamingResponse
+    """
+    wrapper = AWSBedrockWrapper()
+    resp, logs = wrapper.send_awsbedrock_request(
+        "Completion",
+        "create",
+        model=user_input.model,
+        max_tokens=user_input.max_tokens,
+        prompt=user_input.prompt,
+        temperature=user_input.temperature,
+        **user_input.model_kwargs,
+    )
+
+    background_tasks.add_task(wrapper.write_logs_to_db, db_logs=logs)
+    return StreamingResponse(resp, media_type="text/plain")
+
+
+@router.post("/embedding")
+@reraise_500
+def get_embedding(
+    user_input: AWSBedrockEmbeddingInput, background_tasks: BackgroundTasks
+) -> JSONResponse:
+    """
+    Use AWS Bedrock to turn a list of prompts into vectors
+
+    :param user_input: Inputs to the AWS Bedrock embedding API, including model and list of prompts
+    :type user_input: AWSBedrockInput
+    :return: List of embeddings (a vector for each input prompt) and metadata
+    :rtype: JSONResponse
+    """
+    wrapper = AWSBedrockWrapper()
+    resp, logs = wrapper.send_awsbedrock_request(
+        "Embedding",
+        "create",
+        embedding_texts=user_input.embedding_texts,
+        model=user_input.model,
+    )
+    background_tasks.add_task(wrapper.write_logs_to_db, db_logs=logs)
+    return JSONResponse(resp)

--- a/llm_gateway/routers/awsbedrock_api.py
+++ b/llm_gateway/routers/awsbedrock_api.py
@@ -50,9 +50,9 @@ def get_completion(
         awsbedrock_module="Chat",
         model=user_input.model,
         max_tokens=user_input.max_tokens,
-        prompt=user_input.prompt,
+        messages=user_input.messages,
         temperature=user_input.temperature,
-        **user_input.model_kwargs,
+        **user_input.kwargs,
     )
 
     background_tasks.add_task(wrapper.write_logs_to_db, db_logs=logs)
@@ -74,13 +74,12 @@ def get_completion_stream(
     """
     wrapper = AWSBedrockWrapper()
     resp, logs = wrapper.send_awsbedrock_request(
-        "Completion",
-        "create",
+        awsbedrock_module="Chat",
         model=user_input.model,
         max_tokens=user_input.max_tokens,
-        prompt=user_input.prompt,
+        messages=user_input.messages,
         temperature=user_input.temperature,
-        **user_input.model_kwargs,
+        **user_input.kwargs,
     )
 
     background_tasks.add_task(wrapper.write_logs_to_db, db_logs=logs)
@@ -91,8 +90,20 @@ def get_completion_stream(
 @reraise_500
 def get_completion_stream(
     user_input: AWSBedrockTextInput, background_tasks: BackgroundTasks
-) -> StreamingResponse:
-    pass
+) -> JSONResponse:
+    """"""
+    wrapper = AWSBedrockWrapper()
+    resp, logs = wrapper.send_awsbedrock_request(
+        awsbedrock_module="Text",
+        model=user_input.model,
+        max_tokens=user_input.max_tokens,
+        prompt=user_input.prompt,
+        temperature=user_input.temperature,
+        **user_input.kwargs,
+    )
+
+    background_tasks.add_task(wrapper.write_logs_to_db, db_logs=logs)
+    return JSONResponse(resp)
 
 
 @router.post("/text/streaming")
@@ -100,20 +111,55 @@ def get_completion_stream(
 def get_completion_stream(
     user_input: AWSBedrockTextInput, background_tasks: BackgroundTasks
 ) -> StreamingResponse:
-    pass
+    """"""
+    wrapper = AWSBedrockWrapper()
+    resp, logs = wrapper.send_awsbedrock_request(
+        awsbedrock_module="Text",
+        model=user_input.model,
+        max_tokens=user_input.max_tokens,
+        prompt=user_input.prompt,
+        temperature=user_input.temperature,
+        **user_input.kwargs,
+    )
 
+    background_tasks.add_task(wrapper.write_logs_to_db, db_logs=logs)
+    return StreamingResponse(resp, media_type="text/plain")
 
 @router.post("/embed")
 @reraise_500
 def get_completion_stream(
     user_input: AWSBedrockEmbedInput, background_tasks: BackgroundTasks
-) -> StreamingResponse:
-    pass
+) -> JSONResponse:
+    """"""
+    wrapper = AWSBedrockWrapper()
+    resp, logs = wrapper.send_awsbedrock_request(
+        awsbedrock_module="Embed",
+        model=user_input.model,
+        max_tokens=user_input.max_tokens,
+        embedding_texts=user_input.embedding_texts,
+        temperature=user_input.temperature,
+        **user_input.kwargs,
+    )
+
+    background_tasks.add_task(wrapper.write_logs_to_db, db_logs=logs)
+    return JSONResponse(resp)
 
 
 @router.post("/image")
 @reraise_500
 def get_completion_stream(
     user_input: AWSBedrockImageInput, background_tasks: BackgroundTasks
-) -> StreamingResponse:
-    pass
+) -> JSONResponse:
+    """"""
+    wrapper = AWSBedrockWrapper()
+    resp, logs = wrapper.send_awsbedrock_request(
+        awsbedrock_module="Image",
+        model=user_input.model,
+        max_tokens=user_input.max_tokens,
+        prompt=user_input.prompt,
+        temperature=user_input.temperature,
+        **user_input.kwargs,
+    )
+
+    background_tasks.add_task(wrapper.write_logs_to_db, db_logs=logs)
+    return JSONResponse(resp)

--- a/llm_gateway/routers/awsbedrock_api.py
+++ b/llm_gateway/routers/awsbedrock_api.py
@@ -21,18 +21,21 @@ from starlette.responses import JSONResponse
 
 from llm_gateway.exceptions import AWSBedrockRouteExceptionHandler
 from llm_gateway.models import (
-    AWSBedrockCompletionInput,
-    AWSBedrockEmbeddingInput,
+    AWSBedrockChatInput,
+    AWSBedrockEmbedInput,
+    AWSBedrockImageInput,
+    AWSBedrockTextInput,
 )
 from llm_gateway.providers.awsbedrock import AWSBedrockWrapper
 from llm_gateway.utils import reraise_500
 
 router = APIRouter(route_class=AWSBedrockRouteExceptionHandler)
 
-@router.post("/completion")
+
+@router.post("/chat")
 @reraise_500
 def get_completion(
-    user_input: AWSBedrockCompletionInput, background_tasks: BackgroundTasks
+    user_input: AWSBedrockChatInput, background_tasks: BackgroundTasks
 ) -> JSONResponse:
     """
     Use the AWS Bedrock completion API to generate a response to a prompt
@@ -44,8 +47,7 @@ def get_completion(
     """
     wrapper = AWSBedrockWrapper()
     resp, logs = wrapper.send_awsbedrock_request(
-        "Completion",
-        "create",
+        awsbedrock_module="Chat",
         model=user_input.model,
         max_tokens=user_input.max_tokens,
         prompt=user_input.prompt,
@@ -56,10 +58,11 @@ def get_completion(
     background_tasks.add_task(wrapper.write_logs_to_db, db_logs=logs)
     return JSONResponse(resp)
 
-@router.post("/completion/streaming")
+
+@router.post("/chat/streaming")
 @reraise_500
 def get_completion_stream(
-    user_input: AWSBedrockCompletionInput, background_tasks: BackgroundTasks
+    user_input: AWSBedrockChatInput, background_tasks: BackgroundTasks
 ) -> StreamingResponse:
     """
     Use the AWS Bedrock completion API to generate a stream response to a prompt
@@ -84,25 +87,33 @@ def get_completion_stream(
     return StreamingResponse(resp, media_type="text/plain")
 
 
-@router.post("/embedding")
+@router.post("/text")
 @reraise_500
-def get_embedding(
-    user_input: AWSBedrockEmbeddingInput, background_tasks: BackgroundTasks
-) -> JSONResponse:
-    """
-    Use AWS Bedrock to turn a list of prompts into vectors
+def get_completion_stream(
+    user_input: AWSBedrockTextInput, background_tasks: BackgroundTasks
+) -> StreamingResponse:
+    pass
 
-    :param user_input: Inputs to the AWS Bedrock embedding API, including model and list of prompts
-    :type user_input: AWSBedrockInput
-    :return: List of embeddings (a vector for each input prompt) and metadata
-    :rtype: JSONResponse
-    """
-    wrapper = AWSBedrockWrapper()
-    resp, logs = wrapper.send_awsbedrock_request(
-        "Embedding",
-        "create",
-        embedding_texts=user_input.embedding_texts,
-        model=user_input.model,
-    )
-    background_tasks.add_task(wrapper.write_logs_to_db, db_logs=logs)
-    return JSONResponse(resp)
+
+@router.post("/text/streaming")
+@reraise_500
+def get_completion_stream(
+    user_input: AWSBedrockTextInput, background_tasks: BackgroundTasks
+) -> StreamingResponse:
+    pass
+
+
+@router.post("/embed")
+@reraise_500
+def get_completion_stream(
+    user_input: AWSBedrockEmbedInput, background_tasks: BackgroundTasks
+) -> StreamingResponse:
+    pass
+
+
+@router.post("/image")
+@reraise_500
+def get_completion_stream(
+    user_input: AWSBedrockImageInput, background_tasks: BackgroundTasks
+) -> StreamingResponse:
+    pass

--- a/llm_gateway/routers/awsbedrock_api.py
+++ b/llm_gateway/routers/awsbedrock_api.py
@@ -20,75 +20,16 @@ from fastapi.responses import StreamingResponse
 from starlette.responses import JSONResponse
 
 from llm_gateway.exceptions import AWSBedrockRouteExceptionHandler
-from llm_gateway.models import (
-    AWSBedrockChatInput,
-    AWSBedrockEmbedInput,
-    AWSBedrockImageInput,
-    AWSBedrockTextInput,
-)
+from llm_gateway.models import AWSBedrockEmbedInput, AWSBedrockTextInput
 from llm_gateway.providers.awsbedrock import AWSBedrockWrapper
 from llm_gateway.utils import reraise_500
 
 router = APIRouter(route_class=AWSBedrockRouteExceptionHandler)
 
 
-@router.post("/chat")
-@reraise_500
-def get_completion(
-    user_input: AWSBedrockChatInput, background_tasks: BackgroundTasks
-) -> JSONResponse:
-    """
-    Use the AWS Bedrock completion API to generate a response to a prompt
-
-    :param user_input: Inputs to the AWS Bedrock completion API, including model and prompt
-    :type user_input: AWSBedrockCompletionInput
-    :return: Dictionary with LLM response and metadata
-    :rtype: JSONResponse
-    """
-    wrapper = AWSBedrockWrapper()
-    resp, logs = wrapper.send_awsbedrock_request(
-        awsbedrock_module="Chat",
-        model=user_input.model,
-        max_tokens=user_input.max_tokens,
-        messages=user_input.messages,
-        temperature=user_input.temperature,
-        **user_input.kwargs,
-    )
-
-    background_tasks.add_task(wrapper.write_logs_to_db, db_logs=logs)
-    return JSONResponse(resp)
-
-
-@router.post("/chat/streaming")
-@reraise_500
-def get_completion_stream(
-    user_input: AWSBedrockChatInput, background_tasks: BackgroundTasks
-) -> StreamingResponse:
-    """
-    Use the AWS Bedrock completion API to generate a stream response to a prompt
-
-    :param user_input: Inputs to the AWS Bedrock completion API, including model and prompt
-    :type user_input: AWSBedrockCompletionInput
-    :return: LLM response and metadata
-    :rtype: StreamingResponse
-    """
-    wrapper = AWSBedrockWrapper()
-    resp, logs = wrapper.send_awsbedrock_request(
-        awsbedrock_module="Chat",
-        model=user_input.model,
-        max_tokens=user_input.max_tokens,
-        messages=user_input.messages,
-        temperature=user_input.temperature,
-        **user_input.kwargs,
-    )
-
-    background_tasks.add_task(wrapper.write_logs_to_db, db_logs=logs)
-    return StreamingResponse(resp, media_type="text/plain")
-
-
 @router.post("/text")
 @reraise_500
-def get_completion_stream(
+def get_completion_text(
     user_input: AWSBedrockTextInput, background_tasks: BackgroundTasks
 ) -> JSONResponse:
     """"""
@@ -99,35 +40,16 @@ def get_completion_stream(
         max_tokens=user_input.max_tokens,
         prompt=user_input.prompt,
         temperature=user_input.temperature,
-        **user_input.kwargs,
+        **user_input.model_kwargs,
     )
 
     background_tasks.add_task(wrapper.write_logs_to_db, db_logs=logs)
     return JSONResponse(resp)
 
-
-@router.post("/text/streaming")
-@reraise_500
-def get_completion_stream(
-    user_input: AWSBedrockTextInput, background_tasks: BackgroundTasks
-) -> StreamingResponse:
-    """"""
-    wrapper = AWSBedrockWrapper()
-    resp, logs = wrapper.send_awsbedrock_request(
-        awsbedrock_module="Text",
-        model=user_input.model,
-        max_tokens=user_input.max_tokens,
-        prompt=user_input.prompt,
-        temperature=user_input.temperature,
-        **user_input.kwargs,
-    )
-
-    background_tasks.add_task(wrapper.write_logs_to_db, db_logs=logs)
-    return StreamingResponse(resp, media_type="text/plain")
 
 @router.post("/embed")
 @reraise_500
-def get_completion_stream(
+def get_completion_embedding(
     user_input: AWSBedrockEmbedInput, background_tasks: BackgroundTasks
 ) -> JSONResponse:
     """"""
@@ -137,28 +59,6 @@ def get_completion_stream(
         model=user_input.model,
         max_tokens=user_input.max_tokens,
         embedding_texts=user_input.embedding_texts,
-        temperature=user_input.temperature,
-        **user_input.kwargs,
-    )
-
-    background_tasks.add_task(wrapper.write_logs_to_db, db_logs=logs)
-    return JSONResponse(resp)
-
-
-@router.post("/image")
-@reraise_500
-def get_completion_stream(
-    user_input: AWSBedrockImageInput, background_tasks: BackgroundTasks
-) -> JSONResponse:
-    """"""
-    wrapper = AWSBedrockWrapper()
-    resp, logs = wrapper.send_awsbedrock_request(
-        awsbedrock_module="Image",
-        model=user_input.model,
-        max_tokens=user_input.max_tokens,
-        prompt=user_input.prompt,
-        temperature=user_input.temperature,
-        **user_input.kwargs,
     )
 
     background_tasks.add_task(wrapper.write_logs_to_db, db_logs=logs)

--- a/llm_gateway/routers/awsbedrock_api.py
+++ b/llm_gateway/routers/awsbedrock_api.py
@@ -16,7 +16,6 @@
 # limitations under the License.
 
 from fastapi import APIRouter, BackgroundTasks
-from fastapi.responses import StreamingResponse
 from starlette.responses import JSONResponse
 
 from llm_gateway.exceptions import AWSBedrockRouteExceptionHandler
@@ -32,7 +31,14 @@ router = APIRouter(route_class=AWSBedrockRouteExceptionHandler)
 def get_completion_text(
     user_input: AWSBedrockTextInput, background_tasks: BackgroundTasks
 ) -> JSONResponse:
-    """"""
+    """
+    Use the AWS Bedrock API to generate a response to a prompt
+
+    :param user_input: Inputs to the AWS Bedrock API, including prompt
+    :type user_input: AWSBedrockTextInput
+    :return: Dictionary with LLM response and metadata
+    :rtype: JSONResponse
+    """
     wrapper = AWSBedrockWrapper()
     resp, logs = wrapper.send_awsbedrock_request(
         awsbedrock_module="Text",
@@ -52,7 +58,14 @@ def get_completion_text(
 def get_completion_embedding(
     user_input: AWSBedrockEmbedInput, background_tasks: BackgroundTasks
 ) -> JSONResponse:
-    """"""
+    """
+    Use the AWS Bedrock API to generate a embedding vectors from a prompt
+
+    :param user_input: Inputs to the AWS Bedrock API, including prompt
+    :type user_input: AWSBedrockEmbedInput
+    :return: Dictionary with LLM response and metadata
+    :rtype: JSONResponse
+    """
     wrapper = AWSBedrockWrapper()
     resp, logs = wrapper.send_awsbedrock_request(
         awsbedrock_module="Embed",

--- a/poetry.lock
+++ b/poetry.lock
@@ -248,6 +248,44 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "boto3"
+version = "1.33.13"
+description = "The AWS SDK for Python"
+optional = false
+python-versions = ">= 3.7"
+files = [
+    {file = "boto3-1.33.13-py3-none-any.whl", hash = "sha256:5f278b95fb2b32f3d09d950759a05664357ba35d81107bab1537c4ddd212cd8c"},
+    {file = "boto3-1.33.13.tar.gz", hash = "sha256:0e966b8a475ecb06cc0846304454b8da2473d4c8198a45dfb2c5304871986883"},
+]
+
+[package.dependencies]
+botocore = ">=1.33.13,<1.34.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.8.2,<0.9.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
+name = "botocore"
+version = "1.33.13"
+description = "Low-level, data-driven core of boto 3."
+optional = false
+python-versions = ">= 3.7"
+files = [
+    {file = "botocore-1.33.13-py3-none-any.whl", hash = "sha256:aeadccf4b7c674c7d47e713ef34671b834bc3e89723ef96d994409c9f54666e6"},
+    {file = "botocore-1.33.13.tar.gz", hash = "sha256:fb577f4cb175605527458b04571451db1bd1a2036976b626206036acd4496617"},
+]
+
+[package.dependencies]
+jmespath = ">=0.7.1,<2.0.0"
+python-dateutil = ">=2.1,<3.0.0"
+urllib3 = {version = ">=1.25.4,<2.1", markers = "python_version >= \"3.10\""}
+
+[package.extras]
+crt = ["awscrt (==0.19.17)"]
+
+[[package]]
 name = "certifi"
 version = "2023.7.22"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -764,6 +802,17 @@ colors = ["colorama (>=0.4.3)"]
 pipfile-deprecated-finder = ["pip-shims (>=0.5.2)", "pipreqs", "requirementslib"]
 plugins = ["setuptools"]
 requirements-deprecated-finder = ["pip-api", "pipreqs"]
+
+[[package]]
+name = "jmespath"
+version = "1.0.1"
+description = "JSON Matching Expressions"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
+    {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
+]
 
 [[package]]
 name = "mako"
@@ -1469,6 +1518,23 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "s3transfer"
+version = "0.8.2"
+description = "An Amazon S3 Transfer Manager"
+optional = false
+python-versions = ">= 3.7"
+files = [
+    {file = "s3transfer-0.8.2-py3-none-any.whl", hash = "sha256:c9e56cbe88b28d8e197cf841f1f0c130f246595e77ae5b5a05b69fe7cb83de76"},
+    {file = "s3transfer-0.8.2.tar.gz", hash = "sha256:368ac6876a9e9ed91f6bc86581e319be08188dc60d50e0d56308ed5765446283"},
+]
+
+[package.dependencies]
+botocore = ">=1.33.2,<2.0a.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.33.2,<2.0a.0)"]
+
+[[package]]
 name = "setuptools"
 version = "68.0.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -1977,4 +2043,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "3.11.*"
-content-hash = "c813de5f798fa58b3acb98490e3dad5c2a464dfadfb8ab30d00dcca92c78f463"
+content-hash = "47921c9963ff737c6e63bf4e94b103737304987b0a1427d4ced530321e46134b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ sqlalchemy = ">=1.3.0"
 uvicorn = {extras = ["standard"], version = "^0.21.1"}
 openai = {extras = ["datalib"], version = "^0.27.4"}
 cohere = "^4.6.1"
+boto3 = "^1.33.13"
 
 [tool.poetry.group.dev.dependencies]
 black = "23.3.0"


### PR DESCRIPTION
**Why is this change being made?**

This PR adds support for Amazon Bedrock (using Boto3) which gives users access to an additional 15 LLM's.

<details>
<summary>Click to view new-models</summary>

![new-models](https://github.com/wealthsimple/llm-gateway/assets/87831908/fa0ce802-af22-4cf9-b8db-604db705ef86)

</details>

The LLM's being added include: 
- AI21 Labs / Jurassic-2 Ultra
- AI21 Labs / Jurassic-2 Mid
- Amazon / Titan Text Lite
- Amazon / Titan Text Express
- Amazon / Titan Text Embeddings
- Anthropic / Claude 2.1
- Anthropic / Claude 2.0
- Anthropic / Claude 1.3
- Anthropic / Claude Instant
- Cohere / Command
- Cohere / Command Light
- Cohere / Embed - English
- Cohere / Embed - Multilingual
- Meta / Llama-2-13b-chat
- Meta / Llama-2-70b-chat

**What is changing?**

Additional files have been added to the backend `llm_gateway` service to support Amazon Bedrock. `llm_gateway/providers/awsbedrock` contains the boto3 integration in order to send and retrieve data from Amazon Bedrock. 

Most of the LLM models under Amazon Bedrock have specific input / output JSON schema based on the provider and model. The input structure is defined in `llm_gateway/providers/awsbedrock` -> `_structure_model_body()`. The output schema is defined within `front_end/src/constants` in the ParseResponse arrow functions.

The model metadata displayed in the frontend is located in `front_end/src/constants` -> `const modelChoices`. A new section `Model Requirements` has also been added to each model (existing and new).

A new DB table "awsbedrock_requests" has been added to `llm_gateway/db/models` as well as the schema in `fixtures/init.sql`.

`Poetry.lock` and `pyproject.toml` have updated dependencies for boto3.

`.envrc.example` and `llm_gateway/constants` have updated placeholders for AWS keys.

An AWS account is required to use any of the models provisioned through Amazon Bedrock. Each model must be enabled manually within the AWS console before use.

`README.md` and `llm_gateway/README.md` have been updated with information on the models, providers, and setup instructions.

**How did I test?**

Manual testing done for each model, results below: 

<details>
<summary>Click to view meta.llama2-13b-chat-v1</summary>

![meta llama2-13b-chat-v1](https://github.com/wealthsimple/llm-gateway/assets/87831908/2c2b8864-5c9d-47ce-af78-f77ea234119e)

</details>

<details>
<summary>Click to view meta.llama2-70b-chat-v1</summary>

![meta llama2-70b-chat-v1](https://github.com/wealthsimple/llm-gateway/assets/87831908/646b4f8d-4b17-4b19-ab49-7a46de403760)

</details>

<details>
<summary>Click to view ai21.j2-mid-v1</summary>

![ai21 j2-mid-v1](https://github.com/wealthsimple/llm-gateway/assets/87831908/ac0b8e34-d7a3-494c-baf5-f05d477a034e)

</details>

<details>
<summary>Click to view ai21.j2-ultra-v1</summary>

![ai21 j2-ultra-v1](https://github.com/wealthsimple/llm-gateway/assets/87831908/be8b8e50-c034-4f09-857f-eec53fa6d2d0)

</details>

<details>
<summary>Click to view amazon.titan-text-lite-v1</summary>

![amazon titan-text-lite-v1](https://github.com/wealthsimple/llm-gateway/assets/87831908/dc89fc48-6f90-4c6a-b181-de51cdf9f748)

</details>

<details>
<summary>Click to view amazon.titan-text-express-v1</summary>

![amazon titan-text-express-v1](https://github.com/wealthsimple/llm-gateway/assets/87831908/adab2d8b-046d-4f71-9204-8d4ecee164e3)

</details>

<details>
<summary>Click to view anthropic.claude-v1</summary>

![anthropic claude-v1](https://github.com/wealthsimple/llm-gateway/assets/87831908/040a639b-eb39-423c-b722-9e82b2d4c12b)

</details>

<details>
<summary>Click to view anthropic.claude-v2</summary>

![anthropic claude-v2](https://github.com/wealthsimple/llm-gateway/assets/87831908/e607bb11-c56d-4c60-9930-cbeaf5ca89d4)

</details>

<details>
<summary>Click to view anthropic.claude-v2:1</summary>

![anthropic claude-v2 1](https://github.com/wealthsimple/llm-gateway/assets/87831908/1acdd036-8054-4a46-823c-2ec69b5b3c2b)

</details>

<details>
<summary>Click to view anthropic.claude-instant-v1</summary>

![anthropic claude-instant-v1](https://github.com/wealthsimple/llm-gateway/assets/87831908/65d9f517-42f8-4afe-9f0c-03366773f04a)

</details>

<details>
<summary>Click to view cohere.command-text-v14</summary>

![cohere command-light-text-v14](https://github.com/wealthsimple/llm-gateway/assets/87831908/98ed8900-5420-43de-84b5-cd4c554d9e13)

</details>

<details>
<summary>Click to view cohere.command-light-text-v14</summary>

![cohere command-text-v14](https://github.com/wealthsimple/llm-gateway/assets/87831908/f436b157-2b22-4f6d-b95b-e530ad126646)

</details>

<details>
<summary>Click to view amazon.titan-embed-text-v1</summary>

![amazon titan-embed-text-v1](https://github.com/wealthsimple/llm-gateway/assets/87831908/6051529e-984a-4992-91f5-5b3fddd4aca6)

</details>

<details>
<summary>Click to view cohere.embed-english-v3</summary>

![cohere embed-english-v3](https://github.com/wealthsimple/llm-gateway/assets/87831908/ccaa70bd-94dd-43ed-ade6-f3eae7465693)

</details>

<details>
<summary>Click to view cohere.embed-multilingual-v3</summary>

![cohere embed-multilingual-v3](https://github.com/wealthsimple/llm-gateway/assets/87831908/6fbc0a22-9ff6-4b6c-801a-5fb2d41e3780)

</details>

**Next steps and references**

1. Dialog box for model config

All LLM's being added as well as existing Cohere and OpenAI LLM's have parameters that can be modified (i.e., Temperature, Token length, P, K. Some models have even more customization). These values are currently hard-coded but it would be useful to have a button that opens a dialog box to edit the config options for each model.

2. Streaming support for AWS Bedrock models (Most models support streaming with Boto3)

Amazon Bedrock supports streaming for most models, but the stream output is model-specific, so a significant amount of work is required to integrate it within this system. Can be added. 

3. Image support for AWS Bedrock models (Stable Diffusion, Amazon Titan Image Generation)

Amazon Bedrock supports Stable Diffusion XL and Amazon Titan Image Generation, not sure if this is still within the use case of this project but they can be added.

