### PR TITLE
Use a default untitled chat

### DIFF
--- a/front_end/src/app/components/SettingsDialog/settingsDialog.tsx
+++ b/front_end/src/app/components/SettingsDialog/settingsDialog.tsx
@@ -35,10 +35,9 @@ export const ModelSettingsDialog: React.FC<Props> = ({
   const [newTitle, setNewTitle] = useState('');
 
   const createConversation = () => {
-    const title = newTitle.trim();
+    let title = newTitle.trim();
     if (!title) {
-      alert("Chat title can't be empty!");
-      return;
+      title = "Untitled Chat";
     }
     createNewConversation(title, selectedOption);
     closeModal();


### PR DESCRIPTION
**Why is this change being made?**
To create a new chat, users have to jump through some hoops. This'd expedite the process.

**What is changing?**
Set a default "Untitled Chat" if users don't specify

