### PR TITLE
ci: use variable for default runs-on value [skip deploy]

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   check_modified_files:
     name: Check modified files
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.DEFAULT_RUNS_ON }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -37,7 +37,7 @@ jobs:
   frontend_test:
     name: Tests & Lints LLM Gateway Frontend
     if: needs.check_modified_files.outputs.frontend_modified == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.DEFAULT_RUNS_ON }}
     needs:
       - check_modified_files
     steps:
@@ -64,7 +64,7 @@ jobs:
 
   backend_tests:
     name: Tests & Lints LLM Gateway Backend
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.DEFAULT_RUNS_ON }}
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
### Why

The `ubuntu-latest` label is is moving to Ubuntu 24 starting Dec 5th, 2024.

We are changing repositories to use an org-wide variable currently set to `ubuntu-22.04`.

- Ubuntu 22 is an LTS release and should remain supported until 2027.
- Using an org-wide actions variable makes it easier to mass-migrate repos in the future, while still making it relatively easy to customize per-repo, if necessary, using a repostory-level variable to override the org-wide one.

### What Changed

- Replace usage of `ubuntu-latest` / `ubuntu-22.04` with `${{ vars.DEFAULT_RUNS_ON }}` in workflow files
