### PR TITLE
feat/pii date scrubbing

### DIFF
--- a/llm_gateway/pii_scrubber.py
+++ b/llm_gateway/pii_scrubber.py
@@ -127,11 +127,28 @@ def scrub_postal_codes(text: str) -> str:
     )
 
 
+def scrub_dates(text: str) -> str:
+    """
+    Scrub dates in text
+
+    :param text: Input text to scrub
+    :type text: str
+    :return: Input text with any datess scrubbed
+    :rtype: str
+    """
+    return re.sub(
+        r"\b(?:\d{1,2}[-/.]\d{1,2}[-/.]\d{4}|\d{4}[-/.]\d{1,2}[-/.]\d{1,2})\b",
+        "[REDACTED DATE]",
+        text,
+    )
+
+
 ALL_SCRUBBERS = [
     scrub_phone_numbers,
     scrub_credit_card_numbers,
     scrub_email_addresses,
     scrub_postal_codes,
+    scrub_dates,
     # move sin scrubber to the end since it's over-eager
     scrub_sin_numbers,
 ]

--- a/llm_gateway/pii_scrubber.py
+++ b/llm_gateway/pii_scrubber.py
@@ -133,7 +133,7 @@ def scrub_dates(text: str) -> str:
 
     :param text: Input text to scrub
     :type text: str
-    :return: Input text with any datess scrubbed
+    :return: Input text with any dates scrubbed
     :rtype: str
     """
     return re.sub(

--- a/tests/test_pii_scrubber.py
+++ b/tests/test_pii_scrubber.py
@@ -41,6 +41,7 @@ import pytest
 from llm_gateway.pii_scrubber import (
     scrub_all,
     scrub_credit_card_numbers,
+    scrub_dates,
     scrub_email_addresses,
     scrub_phone_numbers,
     scrub_postal_codes,
@@ -143,6 +144,33 @@ def test_scrub_postal_codes(test_postal: str):
     test_text = format_str.format(test_postal)
     expected_text = format_str.format("[REDACTED POSTAL CODE]")
     assert scrub_postal_codes(test_text) == expected_text
+
+
+@pytest.mark.parametrize(
+    argnames=["test_date"],
+    argvalues=[
+        ("08/13/2004",),
+        ("13/08/2004",),
+        ("2004/13/08",),
+        ("2004/08/13",),
+        ("08-13-2004",),
+        ("13-08-2004",),
+        ("2004-13-08",),
+        ("2004-08-13",),
+        ("08.13.2004",),
+        ("13.08.2004",),
+        ("2004.13.08",),
+        ("2004.08.13",),
+        ("8/4/2004",),
+    ],
+)
+def test_scrub_dates(test_date: str):
+    """Test date scrubbing."""
+
+    format_str = "My birthday is {0}."
+    test_text = format_str.format(test_date)
+    expected_text = format_str.format("[REDACTED DATE]")
+    assert scrub_dates(test_text) == expected_text
 
 
 def test_scrub_all_dict():

--- a/tests/test_pii_scrubber.py
+++ b/tests/test_pii_scrubber.py
@@ -149,19 +149,19 @@ def test_scrub_postal_codes(test_postal: str):
 @pytest.mark.parametrize(
     argnames=["test_date"],
     argvalues=[
-        ("08/13/2004",),
-        ("13/08/2004",),
-        ("2004/13/08",),
-        ("2004/08/13",),
-        ("08-13-2004",),
-        ("13-08-2004",),
-        ("2004-13-08",),
-        ("2004-08-13",),
-        ("08.13.2004",),
-        ("13.08.2004",),
-        ("2004.13.08",),
-        ("2004.08.13",),
-        ("8/4/2004",),
+        ("01/01/2000",),
+        ("02/02/2000",),
+        ("2000/03/03",),
+        ("2000/04/04",),
+        ("05-05-2000",),
+        ("06-06-2000",),
+        ("2000-07-07",),
+        ("2000-08-08",),
+        ("09.09.2000",),
+        ("10.10.2000",),
+        ("2000.11.11",),
+        ("2000.12.12",),
+        ("1/1/2000",),
     ],
 )
 def test_scrub_dates(test_date: str):
@@ -246,6 +246,7 @@ def test_pii_scrubber_end_to_end(mock_write_record_to_db, mock_openai_module):
             "My credit card number is 1234-5678-9012-3456",
             "The user's email is email@123.123.123.123, AKA email@domain.ca",
             "The user's postal code is A1A 1A1, AKA a1a1A1",
+            "The user's birthday is 1/1/2000",
         ],
     )
 
@@ -256,6 +257,7 @@ def test_pii_scrubber_end_to_end(mock_write_record_to_db, mock_openai_module):
         "My credit card number is [REDACTED CREDIT CARD NUMBER]",
         "The user's email is [REDACTED EMAIL ADDRESS], AKA [REDACTED EMAIL ADDRESS]",
         "The user's postal code is [REDACTED POSTAL CODE], AKA [REDACTED POSTAL CODE]",
+        "The user's birthday is [REDACTED DATE]",
     ]
 
     # Truncate the result. called_with contains an extra message - the mock response,


### PR DESCRIPTION
**Why is this change being made?**

<!-- Short description of the motivation behind the change, including links to any relevant issues. -->

The purpose of this PR is to sanitize text input from potentially confidential dates, such as dates of births.

Dates of birth are considered sensitive PII and are often used for identity verification. Scrubbing them ensures compliance with privacy regulations.

**What is changing?**

<!-- Short technical summary of the changes made to the code. -->

An additional function `scrub_dates()` has been added, which matches text found in the input against typical date formats. The function replaces dates matching regex patterns with "[REDACTED DATE]".

**How did I test?**

<!-- Short description of how the PR was tested, clear enough for reviewers to replicate.
     Where possible, add screenshots of the changed feature/functionality before and after your change.
-->

Test cases have been added to `tests/test_pii_scrubber.py` which test the pii scrubber against various date formats, including ISO, USA, EUR and variations of each. This includes cases where months and days are single-digit.

Assuming correct env setup, tests can be run using:

`poetry run pytest tests/test_pii_scrubber.py::test_scrub_dates`
