### PR TITLE
chore: pin the dorny/paths-filter github action

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         id: check-files
         with:
           filters: |


### PR DESCRIPTION
### Jira Ticket
https://wealthsimple.atlassian.net/browse/PLDY-113

### Why
Pinning GitHub Actions to a specific commit prevents supply chain attacks. This is part of our [Third-Party GitHub Actions Policy](https://www.notion.so/wealthsimple/Third-Party-GitHub-Actions-Policy-7c7f97af680a4f53bad7396c40028888). It is also recommended by GitHub in the [Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) documentation.

Search "tj-actions leak" if you want to see an example of why pinning third-party actions is necessary.

### What
- Pin the dorny/paths-filter action to de90cc6fb38fc0963ad72b210f1f284cd68cea36 which is the most recent commit
